### PR TITLE
Implement relations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*]
+indent_style = space
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
@@ -10,5 +11,4 @@ max_line_length = 100
 max_line_length = 77
 
 [*.{clj,cljc,edn}]
-indent_style = space
 indent_size = 2

--- a/docs/basic.md
+++ b/docs/basic.md
@@ -5,39 +5,44 @@
 The various shelving implementations define their own mechanisms for constructing
 configurations. These operations should be shared by all implementations.
 
-## shelving.core/open
-- `(open config)`
+## shelving.core/put
+ - `(put conn spec val)`
+ - `(put conn spec id val)`
 
-Opens a configuration, producing a readable and writable shelf.
+Enters a record into a shelf according to its spec in the schema, inserting substructures and updating all relevant rel(ation)s.
+
+For shelves storing "records" not "values", the `id` parameter may be used to either control the ID of the record, say for achieving an upsert.
+
+It is an error to specify the ID when inserting into a "value" shelf.
+
+Shelves must implement this method.
+
+## shelving.core/open
+ - `(open config)`
+
+Opens a shelf for reading or writing.
+
+Shelves must implement this method.
 
 ## shelving.core/flush
-- `(flush conn)`
+ - `(flush conn)`
 
-Good 'ol `fsync(2)`. Flushes the shelf but doesn't close it.
+Flushes (commits) an open shelf.
 
-## shelving.core/close
-- `(close conn)`
-
-Closes an open shelf. No attempt is made to define the effect of closing a shelf twice.
-
-## shelving.core/put
-- `(put conn spec val)`
-- `(put conn spec uuid val)`
-
-Writes a val to the shelf. The spec must name a spec which is legal in the shelf's schema, and which
-val conforms to. If no UUID is provided, then the table's ID generation strategy is used.
+Shelves must implement this method.
 
 ## shelving.core/get
-- `(put conn spec uuid)`
+ - `(get conn spec record-id)`
 
-Fetches a record from the shelf by spec and UUID.
+Fetches a record from a shelf by its spec and ID.
 
-## shelving.core/enumerate-specs
-- `(enumerate-specs conn)`
+Shelves must implement this method.
 
-Returns a sequence all the specs in the shelf.
+## shelving.core/close
+ - `(close conn)`
 
-## shelving.core/enumerate-records
-- `(enumerate-records conn spec)`
+Closes an open shelf.
 
-Returns a sequence of the UUIDs of the records of that spec in the shelf.
+Shelves may implement this method.
+
+By default just flushes.

--- a/docs/basic.md
+++ b/docs/basic.md
@@ -5,7 +5,41 @@
 The various shelving implementations define their own mechanisms for constructing
 configurations. These operations should be shared by all implementations.
 
-## shelving.core/put
+## [shelving.core/open](/src/main/clj/shelving/core.clj#L40)
+ - `(open config)`
+
+Opens a shelf for reading or writing.
+
+Shelves must implement this method.
+
+## [shelving.core/flush](/src/main/clj/shelving/core.clj#L52)
+ - `(flush conn)`
+
+Flushes (commits) an open shelf.
+
+Shelves must implement this method.
+
+By default throws `me.arrdem.UnimplementedOperationException`.
+
+## [shelving.core/close](/src/main/clj/shelving/core.clj#L66)
+ - `(close conn)`
+
+Closes an open shelf.
+
+Shelves may implement this method.
+
+By default just flushes.
+
+## [shelving.core/get](/src/main/clj/shelving/core.clj#L81)
+ - `(get conn spec record-id)`
+
+Fetches a record from a shelf by its spec and ID.
+
+Shelves must implement this method.
+
+By default throws `me.arrdem.UnimplementedOperationException`.
+
+## [shelving.core/put](/src/main/clj/shelving/core.clj#L93)
  - `(put conn spec val)`
  - `(put conn spec id val)`
 
@@ -17,32 +51,16 @@ It is an error to specify the ID when inserting into a "value" shelf.
 
 Shelves must implement this method.
 
-## shelving.core/open
- - `(open config)`
+By default throws `me.arrdem.UnimplementedOperationException`.
 
-Opens a shelf for reading or writing.
+## [shelving.core/schema](/src/main/clj/shelving/core.clj#L115)
+ - `(schema conn)`
 
-Shelves must implement this method.
+Returns the schema record for a given connection.
 
-## shelving.core/flush
- - `(flush conn)`
-
-Flushes (commits) an open shelf.
+Schemas are fixed when the connection is opened.
 
 Shelves must implement this method.
 
-## shelving.core/get
- - `(get conn spec record-id)`
+By default throws `me.arrdem.UnimplementedOperationException`.
 
-Fetches a record from a shelf by its spec and ID.
-
-Shelves must implement this method.
-
-## shelving.core/close
- - `(close conn)`
-
-Closes an open shelf.
-
-Shelves may implement this method.
-
-By default just flushes.

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1,11 +1,26 @@
 # UUID helpers
 
+[back to the index](/README.md#usage)
+
+Utilities for computing UUIDs for use as shelf keys.
 ## shelving.core/random-uuid
-- `(random-uuid & _)`
+ - `(random-uuid _)`
 
-Ignores its arguments and returns a random UUID (UUID4).
+Returns a random UUID.
 
-## shelving.core/texts->sha-uuid
-- `(texts->sha-uuid & texts)`
+## shelving.core/content-hash
+ - `(content-hash val)`
+ - `(content-hash digest-name val)`
 
-Computes the SHA sum of many texts, truncating it to 128bi and returning a UUID with that value.
+A generic Clojure content hash based on using `#'clojure.walk/postwalk` to accumulate hash values from substructures.
+
+For general Objects, takes the `java.lang.Object/hashCode` for each object in postwalk's order. Strings however are fully digested as UTF-8 bytes.
+
+The precise hash used may be configured, but must be of at least 128bi in length as the first 128bi are converted to a UUID, which is returned.
+
+## shelving.core/digest->uuid
+ - `(digest->uuid digest)`
+
+Takes the first 16b of a `byte[]` as a 1228bi UUID.
+
+An `IndexOutOfBoundsException` will probably be thrown if the `byte[]` is too small.

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -3,12 +3,20 @@
 [back to the index](/README.md#usage)
 
 Utilities for computing UUIDs for use as shelf keys.
-## shelving.core/random-uuid
+
+## [shelving.core/random-uuid](/src/main/clj/shelving/core.clj#L160)
  - `(random-uuid _)`
 
 Returns a random UUID.
 
-## shelving.core/content-hash
+## [shelving.core/digest->uuid](/src/main/clj/shelving/core.clj#L168)
+ - `(digest->uuid digest)`
+
+Takes the first 16b of a `byte[]` as a 1228bi UUID.
+
+An `IndexOutOfBoundsException` will probably be thrown if the `byte[]` is too small.
+
+## [shelving.core/content-hash](/src/main/clj/shelving/core.clj#L182)
  - `(content-hash val)`
  - `(content-hash digest-name val)`
 
@@ -18,9 +26,3 @@ For general Objects, takes the `java.lang.Object/hashCode` for each object in po
 
 The precise hash used may be configured, but must be of at least 128bi in length as the first 128bi are converted to a UUID, which is returned.
 
-## shelving.core/digest->uuid
- - `(digest->uuid digest)`
-
-Takes the first 16b of a `byte[]` as a 1228bi UUID.
-
-An `IndexOutOfBoundsException` will probably be thrown if the `byte[]` is too small.

--- a/docs/rel.md
+++ b/docs/rel.md
@@ -1,0 +1,59 @@
+# Rel(ation) API
+
+[back to the index](/README.md#usage)
+
+`clojure.spec(.alpha)` is a set of tools for describing data by composing descriptions of
+substructures. In traditional relational data models, records relate to each-other by referencing
+identifiers which are joined against.
+
+In Prolog/Datalog "fact" databases, data is stored as triples of the form `(rel a b)` where `a` and
+`b` are data including other relational statements.
+
+One can imagine "destructuring" complex objects with specs by using their specs to describe in the
+relational style the superstructure and the substructures. This is basically how relations in
+shelving work.
+
+Using spec, values [[1]](/docs/schema.md#values) (and records [[1]](/docs/schema.md#records))
+
+## shelving.core/enumerate-rel
+ - `(enumerate-rel conn rel-id)`
+
+Enumerates the `(from-id to-id)` pairs of the given rel(ation).
+
+Shelves must implement this method.
+
+## shelving.core/enumerate-rels
+ - `(enumerate-rels conn)`
+
+Enumerates all the known rels by ID (their `[from-spec to-spec]` pair).
+
+Shelves must implement this method.
+
+## shelving.core/spec-rel
+ - `(spec-rel schema [from-spec to-spec :as rel-id] to-fn)`
+
+Enters a rel(ation) into a schema, returning a new schema which will maintain that rel.
+
+rels are identified uniquely by a pair of specs, and the relation is determined by the to-fn which projects instances of the `from-spec` to instances of the `to-spec`. `to-fn` MUST be a pure function.
+
+When inserting with indices, all `to-spec` instances will be inserted into their corresponding tables.
+
+At insertion time, the `to-spec` must exist as a supported shelf.
+
+The `to-spec` MAY NEVER name a "record" shelf. `to-spec` must be a "value" shelf.
+
+## shelving.core/get-from-rel-by-id
+ - `(get-from-rel-by-id conn rel-id spec id)`
+
+**UNSTABLE**: This API will probably change in the future
+
+Given a rel(ation) and the ID of an record of the from-rel spec, return a seq of the IDs of records it relates to.
+
+By default uses `enumerate-rel-by-id` to do a full rel scan.
+
+Shelves may provide more efficient implementations of this method.
+
+## shelving.core/schema->rels
+ - `(schema->rels schema)`
+
+Helper used for converting a schema record to a set of rel(ation)s for storage.

--- a/docs/rel.md
+++ b/docs/rel.md
@@ -13,28 +13,43 @@ One can imagine "destructuring" complex objects with specs by using their specs 
 relational style the superstructure and the substructures. This is basically how relations in
 shelving work.
 
-Using spec, values [[1]](/docs/schema.md#values) (and records [[1]](/docs/schema.md#records))
+Using spec, values [[1]](/docs/schema.md#values) (and records [[1]](/docs/schema.md#records)) can be
+decomposed into their component parts, and the resulting fragments related back to each-other.
 
-## shelving.core/enumerate-rel
- - `(enumerate-rel conn rel-id)`
+Consider for example the following spec -
 
-Enumerates the `(from-id to-id)` pairs of the given rel(ation).
+```clj
+(s/def ::group    string?)
+(s/def ::artifact string?)
+(s/def ::version  string?)
+(s/def ::package-identifier
+  (s/keys :req-un [::group
+                   ::artifact
+                   ::version]))
 
-Shelves must implement this method.
+(s/valid? ::package-identifier
+          {:group "org.clojure"
+           :artifact "clojure"
+           :version "1.10.0"})
+;; => true
+```
 
-## shelving.core/enumerate-rels
- - `(enumerate-rels conn)`
+The `::package-identifier` spec is composed of three string values together in a known
+format. Imagine being able to take a collection of such identifiers, break them down to their
+components and declaratively ask traditional query questions such as "what groups have a clojure
+artifact?" or "what versions of ring are there?".
 
-Enumerates all the known rels by ID (their `[from-spec to-spec]` pair).
+The relations API provides a way to describe how to decompose a spec into its component values so
+that indices can be built for efficient query access.
 
-Shelves must implement this method.
-
-## shelving.core/spec-rel
+## [shelving.core/spec-rel](/src/main/clj/shelving/core.clj#L441)
  - `(spec-rel schema [from-spec to-spec :as rel-id] to-fn)`
 
 Enters a rel(ation) into a schema, returning a new schema which will maintain that rel.
 
-rels are identified uniquely by a pair of specs, and the relation is determined by the to-fn which projects instances of the `from-spec` to instances of the `to-spec`. `to-fn` MUST be a pure function.
+rels are identified uniquely by a pair of specs, stating that there exists a unidirectional relation from values conforming to `from-spec` to values conforming to `to-spec`. This relation has an inverse, which maps values of `to-spec` back to the values of `from-spec` which projected to them.
+
+The rel is determined by the `to-fn` which projects values conforming to the `from-spec` to values conforming to `to-spec`. `to-fn` MUST be a pure function.
 
 When inserting with indices, all `to-spec` instances will be inserted into their corresponding tables.
 
@@ -42,18 +57,60 @@ At insertion time, the `to-spec` must exist as a supported shelf.
 
 The `to-spec` MAY NEVER name a "record" shelf. `to-spec` must be a "value" shelf.
 
-## shelving.core/get-from-rel-by-id
- - `(get-from-rel-by-id conn rel-id spec id)`
+## [shelving.core/has-rel?](/src/main/clj/shelving/core.clj#L484)
+ - `(has-rel? schema [from-spec to-spec :as rel-id])`
+
+True if and only if both specs in the named rel, and the named rel exist in the schema.
+
+## [shelving.core/is-alias?](/src/main/clj/shelving/core.clj#L500)
+ - `(is-alias? schema rel-id)`
+
+True if and only if the schema has the relation (`#'has-rel?`) and the relation is an alias.
+
+## [shelving.core/resolve-alias](/src/main/clj/shelving/core.clj#L515)
+ - `(resolve-alias schema rel-id)`
+
+When the schema has a rel (`#'has-rel?`) and it is an alias (`#'is-alias?`) resolve it, returning the directed rel it aliases. Otherwise return the rel.
+
+## [shelving.core/enumerate-rels](/src/main/clj/shelving/core.clj#L527)
+ - `(enumerate-rels conn)`
+
+Enumerates all the known rels by ID (their `[from-spec to-spec]` pair). Includes aliases.
+
+Shelves may provide alternate implementation of this method.
+
+## [shelving.core/enumerate-rel](/src/main/clj/shelving/core.clj#L540)
+ - `(enumerate-rel conn rel-id)`
+
+Enumerates the `(from-id to-id)` pairs of the given rel(ation).
+
+Shelves must implement this method.
+
+By default throws `me.arrdem.UnimplementedOperationException`.
+
+## [shelving.core/relate-by-id](/src/main/clj/shelving/core.clj#L554)
+ - `(relate-by-id conn rel-id spec id)`
 
 **UNSTABLE**: This API will probably change in the future
 
-Given a rel(ation) and the ID of an record of the from-rel spec, return a seq of the IDs of records it relates to.
+Given a rel(ation), being a pair `[from-spec to-spec]` and the ID of a record of the `from-spec` spec, return a seq of the IDs of records it relates to in `to-spec`.
 
-By default uses `enumerate-rel-by-id` to do a full rel scan.
+If the given ID does not exist on the left side of the given relation, an empty seq must be produced.
+
+Note that if the rel `[a b]` was created with `#'spec-rel`, the rel `[b a]` also exists and is the complement of mapping from `a`s to `b`s defined by `[a b]`.
+
+By default uses [`#'enumerate-rel`](#enumerate-rel) to do a full scan of the pairs constituting this relation.
 
 Shelves may provide more efficient implementations of this method.
 
-## shelving.core/schema->rels
- - `(schema->rels schema)`
+## [shelving.core/relate-by-value](/src/main/clj/shelving/core.clj#L583)
+ - `(relate-by-value conn rel-id spec id)`
 
-Helper used for converting a schema record to a set of rel(ation)s for storage.
+**UNSTABLE**: This API will probably change in the future
+
+Given a rel(ation) and a value conforming to the left side of the relation, return a seq of the IDs of records on the right side of the relation (if any) it relates to.
+
+By default uses [`#'enumerate-rel`](#enumerate-rel) to do a full rel scan.
+
+Shelves may provide more efficient implementations of this method.
+

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -13,64 +13,45 @@ Shelves are expected to persist and check their schemas across close and re-open
 
 There are two kinds of supported specs - "value" specs and "record" specs.
 
-#### Records
+In traditional databases, one stores <span name="records">**"records"**</span> - places with unique
+identifiers which may be updated. Records can be inserted, updated and removed.
 
-In traditional databases, one stores "records" - places with unique identifiers which may be
-updated. Records can be inserted, updated and removed.
+In keeping with Clojure's focus on data, Shelving also supports content or <span name="values">**"value"**</span>
+storage of immutable objects. Values can only be inserted.
 
-#### Values
-
-In keeping with Clojure's focus on data, Shelving also supports content or "value" storage of
-immutable objects. Values can only be inserted.
-
-## shelving.core/enumerate-specs
+## [shelving.core/enumerate-specs](/src/main/clj/shelving/core.clj#L131)
  - `(enumerate-specs conn)`
 
 Enumerates all the known specs.
 
-Shelves must implement this method.
+Shelves may provide alternate implementations of this method.
 
-## shelving.core/is-record?
- - `(is-record? schema spec)`
-
-True if and only if the spec exists and is a record spec.
-
-## shelving.core/id-for-val
- - `(id-for-val schema spec val)`
-
-Returns the `val`'s identifying UUID according to the spec's schema entry.
-
-## shelving.core/empty-schema
-
-The empty Shelving schema.
-
-Should be used as the basis for all user-defined schemas.
-
-## shelving.core/enumerate-spec
+## [shelving.core/enumerate-spec](/src/main/clj/shelving/core.clj#L144)
  - `(enumerate-spec conn spec)`
 
 Enumerates all the known records of a spec by UUID.
 
 Shelves must implement this method.
 
-## shelving.core/is-value?
+By default throws `me.arrdem.UnimplementedOperationException`.
+
+## [shelving.core/empty-schema](/src/main/clj/shelving/core.clj#L251)
+
+The empty Shelving schema.
+
+Should be used as the basis for all user-defined schemas.
+
+## [shelving.core/has-spec?](/src/main/clj/shelving/core.clj#L283)
+ - `(has-spec? schema spec)`
+
+Helper used for preconditions.
+
+## [shelving.core/is-value?](/src/main/clj/shelving/core.clj#L296)
  - `(is-value? schema spec)`
 
 True if and only if the spec exists and is a `:value` spec.
 
-## shelving.core/record-spec
- - `(record-spec schema spec & {:as opts})`
-
-Enters a new "record" spec into a schema, returning a new schema.
-
-Records have traditional place semantics and are identified by randomly generated IDs, rather than the structural semantics ascribed to values.
-
-## shelving.core/schema->specs
- - `(schema->specs schema)`
-
-Helper used for converting a schema record to a set of specs for storage.
-
-## shelving.core/value-spec
+## [shelving.core/value-spec](/src/main/clj/shelving/core.clj#L309)
  - `(value-spec schema spec & {:as opts})`
 
 Enters a new "value" spec into a schema, returning a new schema.
@@ -79,7 +60,25 @@ Values are addressed by a content hash derived ID, are unique and cannot be dele
 
 Values may be related to other values via schema rel(ation)s. Records may relate to values, but values cannot relate to records except through reverse lookup on a record to value relation.
 
-## shelving.core/has-spec?
- - `(has-spec? schema spec)`
+## [shelving.core/is-record?](/src/main/clj/shelving/core.clj#L339)
+ - `(is-record? schema spec)`
 
-Helper used for preconditions.
+True if and only if the spec exists and is a record spec.
+
+## [shelving.core/record-spec](/src/main/clj/shelving/core.clj#L352)
+ - `(record-spec schema spec & {:as opts})`
+
+Enters a new "record" spec into a schema, returning a new schema.
+
+Records have traditional place semantics and are identified by randomly generated IDs, rather than the structural semantics ascribed to values.
+
+## [shelving.core/id-for-record](/src/main/clj/shelving/core.clj#L379)
+ - `(id-for-record schema spec val)`
+
+Returns the `val`'s identifying UUID according to the spec's schema entry.
+
+## [shelving.core/schema->specs](/src/main/clj/shelving/core.clj#L396)
+ - `(schema->specs schema)`
+
+Helper used for converting a schema record to a set of specs for storage.
+

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,20 +1,85 @@
 # Schema API
 
-Shelving leverages clojure.spec to achieve data validation. Schemas are a tool for talking about the
-set of specs which a shelf expects to be able to round-trip. At present, schemas also provide an
-interface for defining the ID generation behavior used for a given spec.
+[back to the index](/README.md#usage)
+
+Shelving leverages `clojure.spec(.alpha)` to achieve data validation and describe the structure of
+data. Schemas are a tool for talking about the set of specs which a shelf expects to be able to
+round-trip.
+
+A Shelving Schema consists of all the specs for data which may be stored, and the
+[rel(ation)s](/doc/rel.md) which connect them.
 
 Shelves are expected to persist and check their schemas across close and re-open.
 
-In the future the schema structure may be used to define indices and relations between specs in a
-shelf's schema.
+There are two kinds of supported specs - "value" specs and "record" specs.
+
+#### Records
+
+In traditional databases, one stores "records" - places with unique identifiers which may be
+updated. Records can be inserted, updated and removed.
+
+#### Values
+
+In keeping with Clojure's focus on data, Shelving also supports content or "value" storage of
+immutable objects. Values can only be inserted.
+
+## shelving.core/enumerate-specs
+ - `(enumerate-specs conn)`
+
+Enumerates all the known specs.
+
+Shelves must implement this method.
+
+## shelving.core/is-record?
+ - `(is-record? schema spec)`
+
+True if and only if the spec exists and is a record spec.
+
+## shelving.core/id-for-val
+ - `(id-for-val schema spec val)`
+
+Returns the `val`'s identifying UUID according to the spec's schema entry.
 
 ## shelving.core/empty-schema
 
-The empty schema.
+The empty Shelving schema.
 
-## shelving.core/shelf-spec
-- `(shelf-spec schema spec id-fn & opts)`
+Should be used as the basis for all user-defined schemas.
 
-Adds a spec to the schema, returning an updated schema. The spec must be accompanied with a function
-from a record conforming to that spec to a UUID. In the future other options may be supported.
+## shelving.core/enumerate-spec
+ - `(enumerate-spec conn spec)`
+
+Enumerates all the known records of a spec by UUID.
+
+Shelves must implement this method.
+
+## shelving.core/is-value?
+ - `(is-value? schema spec)`
+
+True if and only if the spec exists and is a `:value` spec.
+
+## shelving.core/record-spec
+ - `(record-spec schema spec & {:as opts})`
+
+Enters a new "record" spec into a schema, returning a new schema.
+
+Records have traditional place semantics and are identified by randomly generated IDs, rather than the structural semantics ascribed to values.
+
+## shelving.core/schema->specs
+ - `(schema->specs schema)`
+
+Helper used for converting a schema record to a set of specs for storage.
+
+## shelving.core/value-spec
+ - `(value-spec schema spec & {:as opts})`
+
+Enters a new "value" spec into a schema, returning a new schema.
+
+Values are addressed by a content hash derived ID, are unique and cannot be deleted or updated.
+
+Values may be related to other values via schema rel(ation)s. Records may relate to values, but values cannot relate to records except through reverse lookup on a record to value relation.
+
+## shelving.core/has-spec?
+ - `(has-spec? schema spec)`
+
+Helper used for preconditions.

--- a/project.clj
+++ b/project.clj
@@ -17,9 +17,10 @@
                    :source-paths   ["src/dev/clj"
                                     "src/dev/clj"]
                    :resource-paths ["src/dev/resources"]
-                   }}
+                   :doc-paths      ["README.md" "docs"]}}
 
-  :plugins [[me.arrdem/lein-git-version "2.0.4"]]
+  :plugins [[me.arrdem/lein-git-version "2.0.4"]
+            [me.arrdem/lein-auto "0.1.4"]]
   :git-version {:status-to-version
                 (fn [{:keys [tag version branch ahead ahead? dirty?] :as git}]
                   (if (and tag (not ahead?) (not dirty?))
@@ -31,5 +32,7 @@
                             patch            (Long/parseLong patch)
                             patch+           (inc patch)]
                         (format "%s.%d-%s-SNAPSHOT" prefix patch+ branch))
+                      "0.1.0-SNAPSHOT")))}
 
-                      "0.1.0-SNAPSHOT")))})
+  :auto           {"test" {:file-pattern #"\.(clj|cljs|cljx|cljc|edn|md)$"
+                           :paths        [:source-paths :test-paths :doc-paths]}})

--- a/project.clj
+++ b/project.clj
@@ -7,20 +7,24 @@
                  [org.clojure/spec.alpha "0.1.143"]
                  [org.clojure/core.match "0.3.0-alpha5"]]
 
-  :source-paths   ["src/main/clj"
-                   "src/main/cljc"]
-  :test-paths     ["src/test/clj"
-                   "src/test/cljc"]
+  :source-paths      ["src/main/clj"
+                      "src/main/cljc"]
+  :java-source-paths ["src/main/jvm"]
+  :test-paths        ["src/test/clj"
+                      "src/test/cljc"]
 
   :resource-paths ["src/main/resources"]
-  :profiles {:dev {:dependencies   [[org.clojure/test.check "0.10.0-alpha2"]]
-                   :source-paths   ["src/dev/clj"
-                                    "src/dev/clj"]
-                   :resource-paths ["src/dev/resources"]
-                   :doc-paths      ["README.md" "docs"]}}
+  :profiles {:dev {:dependencies      [[org.clojure/test.check "0.10.0-alpha2"]]
+                   :source-paths      ["src/dev/clj"
+                                       "src/dev/clj"]
+                   :java-source-paths ["src/dev/jvm"]
+                   :resource-paths    ["src/dev/resources"]
+                   :doc-paths         ["README.md" "docs"]}}
 
   :plugins [[me.arrdem/lein-git-version "2.0.4"]
-            [me.arrdem/lein-auto "0.1.4"]]
+            [me.arrdem/lein-auto "0.1.4"]
+            [lein-cljfmt "0.5.7"]]
+
   :git-version {:status-to-version
                 (fn [{:keys [tag version branch ahead ahead? dirty?] :as git}]
                   (if (and tag (not ahead?) (not dirty?))
@@ -34,5 +38,8 @@
                         (format "%s.%d-%s-SNAPSHOT" prefix patch+ branch))
                       "0.1.0-SNAPSHOT")))}
 
-  :auto           {"test" {:file-pattern #"\.(clj|cljs|cljx|cljc|edn|md)$"
-                           :paths        [:source-paths :test-paths :doc-paths]}})
+  :auto {"test" {:file-pattern #"\.(clj|cljs|cljx|cljc|edn|md)$"
+                 :paths        [:source-paths :test-paths :doc-paths]}}
+
+  :cljfmt {:indents {quick-check [[:block 1]]
+                     for-all     [[:block 1]]}})

--- a/src/dev/clj/compile_docs.clj
+++ b/src/dev/clj/compile_docs.clj
@@ -1,0 +1,39 @@
+(ns compile-docs
+  "A quick hack for building the doc tree based on `^:category` data."
+  (:require [shelving.core :as sh]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(def category-map
+  {::sh/basic  (io/file "docs/basic.md")
+   ::sh/schema (io/file "docs/schema.md")
+   ::sh/rel    (io/file "docs/rel.md")
+   ::sh/util   (io/file "docs/helpers.md")})
+
+(defn ensure-trailing-newline [s]
+  (if-not (.endsWith s "\n")
+    (str s "\n") s))
+
+(defn compile-docs [category-map nss]
+  (doseq [ns              nss
+          :let            [ns (if-not (instance? clojure.lang.Namespace ns)
+                                (the-ns ns) ns)]
+          [sym maybe-var] (ns-publics ns)
+          :when           (instance? clojure.lang.Var maybe-var)
+          :let            [{:keys [categories arglists doc unstable]
+                            :as   var-meta} (meta maybe-var)]]
+    (when-let [category-file (first (keep category-map categories))]
+      (println ns sym category-file)
+      (with-open [w (io/writer category-file :append true)]
+        (binding [*out* w]
+          (printf "## %s/%s\n" (ns-name ns) sym)
+          (doseq [params arglists]
+            (printf " - `%s`\n" (cons sym params)))
+          (printf "\n")
+          (when unstable
+            (printf "**UNSTABLE**: This API will probably change in the future\n\n"))
+          (printf (ensure-trailing-newline
+                   (-> doc
+                       (str/replace #"(?<!\n)\n[\s&&[^\n\r]]+" " ")
+                       (str/replace #"\n\n[\s&&[^\n\r]]+" "\n\n"))))
+          (printf "\n"))))))

--- a/src/dev/clj/compile_docs.clj
+++ b/src/dev/clj/compile_docs.clj
@@ -14,26 +14,46 @@
   (if-not (.endsWith s "\n")
     (str s "\n") s))
 
+(defn relativize-path [p]
+  (str/replace p (.getCanonicalPath (io/file ".")) ""))
+
 (defn compile-docs [category-map nss]
-  (doseq [ns              nss
-          :let            [ns (if-not (instance? clojure.lang.Namespace ns)
-                                (the-ns ns) ns)]
-          [sym maybe-var] (ns-publics ns)
-          :when           (instance? clojure.lang.Var maybe-var)
-          :let            [{:keys [categories arglists doc unstable]
-                            :as   var-meta} (meta maybe-var)]]
-    (when-let [category-file (first (keep category-map categories))]
-      (println ns sym category-file)
+  (let [vars (for [ns              nss
+                   :let            [ns (if-not (instance? clojure.lang.Namespace ns)
+                                         (the-ns ns) ns)]
+                   [sym maybe-var] (ns-publics ns)
+                   :when           (instance? clojure.lang.Var maybe-var)]
+               maybe-var)
+
+        groupings (group-by #(-> % meta :categories first) vars)]
+    (println groupings)
+    (doseq [[category vars] groupings
+            :let            [category-file (get category-map category)]
+            :when           category-file
+            v               (sort-by #(-> % meta :line) vars) ;; FIXME: better scoring heuristic?
+            :let            [{:keys [categories arglists doc stability line file]
+                              :as   var-meta} (meta v)]]
+      (println v)
       (with-open [w (io/writer category-file :append true)]
         (binding [*out* w]
-          (printf "## %s/%s\n" (ns-name ns) sym)
+          (printf "## [%s/%s](%s#L%s)\n"
+                  (ns-name (.ns v)) (.sym v)
+                  (relativize-path file) line)
           (doseq [params arglists]
-            (printf " - `%s`\n" (cons sym params)))
+            (printf " - `%s`\n" (cons (.sym v) params)))
           (printf "\n")
-          (when unstable
+          (when (= stability :stability/unstable)
             (printf "**UNSTABLE**: This API will probably change in the future\n\n"))
           (printf (ensure-trailing-newline
                    (-> doc
                        (str/replace #"(?<!\n)\n[\s&&[^\n\r]]+" " ")
                        (str/replace #"\n\n[\s&&[^\n\r]]+" "\n\n"))))
           (printf "\n"))))))
+
+(defn recompile-docs [category-map nss]
+  (doseq [[_cat f] category-map]
+    (let [buff      (slurp f)
+          truncated (str/replace buff #"(?s)\n+##.++" "\n\n")]
+      (spit f truncated)))
+
+  (compile-docs category-map nss))

--- a/src/main/clj/shelving/core.clj
+++ b/src/main/clj/shelving/core.clj
@@ -11,44 +11,14 @@
   complexity of a more traditional storage layer or database."
   {:authors ["Reid \"arrdem\" McKenzie <me@arrdem.com>"]
    :license "Eclipse Public License 1.0"
-   :added   "0.1.0"}
+   :added   "0.0.0"}
   (:refer-clojure :exclude [flush get])
   (:import [java.util UUID]
            [java.security MessageDigest]
-           [java.nio ByteBuffer])
+           [java.nio ByteBuffer]
+           [me.arrdem UnimplementedOperationException])
   (:require [clojure.walk :refer [postwalk]]
             [clojure.spec.alpha :as s]))
-
-;; Intentional interface for shelves
-;;--------------------------------------------------------------------------------------------------
-(defmulti open
-  "Opens a shelf for reading or writing.
-
-  Shelves must implement this method."
-  {:categories #{::basic}
-   :arglists   '([config])}
-  :type)
-
-(defmulti flush
-  "Flushes (commits) an open shelf.
-
-  Shelves must implement this method."
-  {:categories #{::basic}
-   :arglists   '([conn])}
-  :type)
-
-(defmulti close
-  "Closes an open shelf.
-
-  Shelves may implement this method.
-
-  By default just flushes."
-  {:categories #{::basic}
-   :arglists   '([conn])}
-  :type)
-
-(defmethod close :default [t]
-  (flush t))
 
 (defn- dx
   ([{:keys [type]}] type)
@@ -58,11 +28,65 @@
   ([{:keys [type]} _ _ _ _] type)
   ([{:keys [type]} _ _ _ _ _] type))
 
-(defmulti get
-  "Fetches a record from a shelf by its spec and ID.
+(defmacro ^:private required! [method]
+  `(defmethod ~method :default [~'& args#]
+     (throw
+      (UnimplementedOperationException.
+       (format "Shelves must implement method %s, no implementation for dispatch tag %s"
+               (pr-str (var ~method)) (apply dx args#))))))
+
+;; Intentional interface for shelves
+;;--------------------------------------------------------------------------------------------------
+(defmulti open
+  "Opens a shelf for reading or writing.
 
   Shelves must implement this method."
   {:categories #{::basic}
+   :stability  :stability/stable
+   :added      "0.0.0"
+   :arglists   '([config])}
+  #'dx)
+
+(required! open)
+
+(defmulti flush
+  "Flushes (commits) an open shelf.
+
+  Shelves must implement this method.
+
+  By default throws `me.arrdem.UnimplementedOperationException`."
+  {:categories #{::basic}
+   :stability  :stability/stable
+   :added      "0.0.0"
+   :arglists   '([conn])}
+  #'dx)
+
+(required! flush)
+
+(defmulti close
+  "Closes an open shelf.
+
+  Shelves may implement this method.
+
+  By default just flushes."
+  {:categories #{::basic}
+   :stability  :stability/stable
+   :added      "0.0.0"
+   :arglists   '([conn])}
+  #'dx)
+
+(defmethod close :default [t]
+  (flush t))
+
+(defmulti get
+  "Fetches a record from a shelf by its spec and ID.
+
+  Shelves must implement this method.
+
+  By default throws `me.arrdem.UnimplementedOperationException`."
+  {:categories #{::basic}
+   :stability  :stability/stable
+   :added      "0.0.0"
    :arglists   '([conn spec record-id])}
   #'dx)
 
@@ -76,33 +100,68 @@
 
   It is an error to specify the ID when inserting into a \"value\" shelf.
 
-  Shelves must implement this method."
+  Shelves must implement this method.
+
+  By default throws `me.arrdem.UnimplementedOperationException`."
   {:categories #{::basic}
+   :stability  :stability/stable
+   :added      "0.0.0"
    :arglists   '([conn spec val]
                  [conn spec id val])}
   #'dx)
 
+(required! put)
+
+(defmulti schema
+  "Returns the schema record for a given connection.
+
+  Schemas are fixed when the connection is opened.
+
+  Shelves must implement this method.
+
+  By default throws `me.arrdem.UnimplementedOperationException`."
+  {:categories #{::basic}
+   :stability  :stability/stable
+   :added      "0.0.0"
+   :arglists   '([conn])}
+  #'dx)
+
+(required! schema)
+
 (defmulti enumerate-specs
   "Enumerates all the known specs.
 
-  Shelves must implement this method."
+  Shelves may provide alternate implementations of this method."
   {:categories #{::schema}
+   :stability  :stability/stable
+   :added      "0.0.0"
    :arglists   '([conn])}
   #'dx)
+
+(defmethod enumerate-specs :default [conn]
+  (-> conn schema :specs keys))
 
 (defmulti enumerate-spec
   "Enumerates all the known records of a spec by UUID.
 
-  Shelves must implement this method."
+  Shelves must implement this method.
+
+  By default throws `me.arrdem.UnimplementedOperationException`."
   {:categories #{::schema}
+   :stability  :stability/stable
+   :added      "0.0.0"
    :arglists   '([conn spec])}
   #'dx)
+
+(required! enumerate-spec)
 
 ;; ID tools
 ;;--------------------------------------------------------------------------------------------------
 (defn random-uuid
   "Returns a random UUID."
-  {:categories #{::util}}
+  {:categories #{::util}
+   :added      "0.0.0"
+   :stability  :stability/stable}
   [_]
   (UUID/randomUUID))
 
@@ -111,7 +170,9 @@
 
   An `IndexOutOfBoundsException` will probably be thrown if the
   `byte[]` is too small."
-  {:categories #{::util}}
+  {:categories #{::util}
+   :added      "0.0.0"
+   :stability  :stability/stable}
   [digest]
   (let [buff (ByteBuffer/wrap digest)]
     (UUID.
@@ -130,7 +191,9 @@
   The precise hash used may be configured, but must be of at least
   128bi in length as the first 128bi are converted to a UUID, which is
   returned."
-  {:categories #{::util}}
+  {:categories #{::util}
+   :added      "0.0.0"
+   :stability  :stability/stable}
   ([val]
    (content-hash "SHA-256" val))
   ([digest-name val]
@@ -149,13 +212,59 @@
 
 ;; Intentional interface for schemas
 ;;--------------------------------------------------------------------------------------------------
+
+;; Specs
+(s/def ::spec-id
+  qualified-keyword?)
+
+(s/def :shelving.core.spec/type
+  #{::spec})
+
+(s/def :shelving.core.spec/record?
+  boolean?)
+
+(s/def :shelving.core.spec/id-fn
+  ifn?)
+
+(s/def :shelving.core.spec/rels
+  (s/coll-of #(s/valid? ::rel-id %)))
+
+(s/def :shelving.core/spec
+  (s/keys :req-un [:shelving.core.spec/type
+                   :shelving.core.spec/record?
+                   :shelving.core.spec/id-fn
+                   :shelving.core.spec/rels]))
+
+(s/def :shelving.core.schema/type #{::schema})
+
+(s/def :shelving.core.schema/specs
+  (s/map-of #(s/valid? ::spec-id %) #(s/valid? ::spec %)))
+
+(s/def :shelving.core.schema/rels
+  (s/map-of #(s/valid? ::rel-id %) #(s/valid? ::rel+alias %)))
+
+(s/def ::schema
+  (s/keys :req-un [:shelving.core.schema/type
+                   :shelving.core.schema/specs
+                   :shelving.core.schema/rels]))
+
 (def ^{:doc "The empty Shelving schema.
 
   Should be used as the basis for all user-defined schemas."
-       :categories #{::schema}}
+       :categories #{::schema}
+       :stability  :stability/stable
+       :added      "0.0.0"}
   empty-schema
   {:type  ::schema
-   :specs {}})
+   :specs {}
+   :rels  {}})
+
+(s/fdef shelf-spec*
+        :args (s/cat :schema ::schema
+                     :spec ::spec
+                     :record? boolean?
+                     :id-fn :shelving.core.spec/id-fn)
+        :ret ::schema)
 
 (defn ^:private shelf-spec*
   "Implementation detail of record-spec and value-spec."
@@ -166,17 +275,36 @@
                     :id-fn   id-fn
                     :rels    #{}}))
 
+(s/fdef has-spec?
+        :args (s/cat :schema ::schema
+                     :spec   ::spec)
+        :ret boolean?)
+
 (defn has-spec?
   "Helper used for preconditions."
-  {:categories #{::schema}}
+  {:categories #{::schema}
+   :stability  :stability/stable
+   :added      "0.0.0"}
   [schema spec]
   (boolean (some-> schema :specs spec)))
 
+(s/fdef is-value?
+        :args (s/cat :schema ::schema
+                     :spec   ::spec)
+        :ret boolean?)
+
 (defn is-value?
   "True if and only if the spec exists and is a `:value` spec."
-  {:categories #{::schema}}
+  {:categories #{::schema}
+   :stability  :stability/stable
+   :added      "0.0.0"}
   [schema spec]
   (boolean (some-> schema :specs spec :record? not)))
+
+(s/fdef value-spec
+        :args (s/cat :schema ::schema
+                     :spec   ::spec)
+        :ret ::schema)
 
 (defn value-spec
   "Enters a new \"value\" spec into a schema, returning a new schema.
@@ -188,7 +316,9 @@
   rel(ation)s. Records may relate to values, but values cannot relate
   to records except through reverse lookup on a record to value
   relation."
-  {:categories #{::schema}}
+  {:categories #{::schema}
+   :stability  :stability/stable
+   :added      "0.0.0"}
   [schema spec & {:as opts}]
   {:pre  [(keyword? spec)
           (namespace spec)
@@ -201,11 +331,23 @@
       (println "Warning: value-spec got ignored opts" opts)))
   (shelf-spec* schema spec false content-hash))
 
+(s/fdef is-record?
+        :args (s/cat :schema ::schema
+                     :spec   ::spec)
+        :ret boolean?)
+
 (defn is-record?
   "True if and only if the spec exists and is a record spec."
-  {:categories #{::schema}}
+  {:categories #{::schema}
+   :stability  :stability/stable
+   :added      "0.0.0"}
   [schema spec]
   (boolean (some-> schema :specs spec :record?)))
+
+(s/fdef record-spec
+        :args (s/cat :schema ::schema
+                     :spec   ::spec)
+        :ret ::schema)
 
 (defn record-spec
   "Enters a new \"record\" spec into a schema, returning a new schema.
@@ -213,7 +355,9 @@
   Records have traditional place semantics and are identified by
   randomly generated IDs, rather than the structural semantics
   ascribed to values."
-  {:categories #{::schema}}
+  {:categories #{::schema}
+   :stability  :stability/stable
+   :added      "0.0.0"}
   [schema spec & {:as opts}]
   {:pre  [(keyword? spec)
           (namespace spec)
@@ -226,9 +370,17 @@
       (println "Warning: record-spec got ignored opts" opts)))
   (shelf-spec* schema spec true random-uuid))
 
-(defn id-for-val
+(s/fdef id-for-record
+        :args (s/cat :schema ::schema
+                     :spec   ::spec
+                     :val    some)
+        :ret uuid?)
+
+(defn id-for-record
   "Returns the `val`'s identifying UUID according to the spec's schema entry."
-  {:categories #{::schema}}
+  {:categories #{::schema}
+   :stability  :stability/stable
+   :added      "0.0.0"}
   [schema spec val]
   {:pre [(has-spec? schema spec)]}
   (let [key-fn (-> schema
@@ -237,21 +389,68 @@
                    (clojure.core/get :id-fn random-uuid))]
     (key-fn val)))
 
+(s/fdef schema->specs
+        :args (s/cat :schema ::schema)
+        :ret (s/coll-of #(s/valid? ::spec %) :kind set?))
+
 (defn schema->specs
   "Helper used for converting a schema record to a set of specs for storage."
-  {:categories #{::schema}}
+  {:categories #{::schema}
+   :stability  :stability/stable
+   :added      "0.0.0"}
   [schema]
   (-> schema :specs keys set))
 
 ;; Relations
 ;;--------------------------------------------------------------------------------------------------
+;; Relations (and aliases) have IDs
+(s/def ::rel-id
+  (s/tuple ::spec-id ::spec-id))
+
+(s/def :shelving.core.rel/type
+  #{::rel})
+
+(s/def :shelving.core.rel/to-fn
+  ifn?)
+
+(s/def ::rel
+  (s/keys :req-un [:shelving.core.rel/type
+                   :shelving.core.rel/to-fn]))
+
+;; Relations may have aliases
+(s/def :shelving.core.alias/type
+  #{::alias})
+
+(s/def :shelving.core.alias/to
+  ::rel-id)
+
+(s/def ::alias
+  (s/keys :req-un [:shelving.core.alias/type
+                   :shelving.core.alias/to]))
+
+;; Really when we way rel we mean either a rel or an alias
+(s/def ::rel+alias
+  (s/or :rel ::rel :alias ::alias))
+
+(s/fdef spec-rel
+        :args (s/cat :schema ::schema
+                     :rel-id ::rel-id
+                     :to-fn ifn?)
+        :ret ::schema)
+
 (defn spec-rel
   "Enters a rel(ation) into a schema, returning a new schema which will
   maintain that rel.
 
-  rels are identified uniquely by a pair of specs, and the relation is
-  determined by the to-fn which projects instances of the `from-spec`
-  to instances of the `to-spec`. `to-fn` MUST be a pure function.
+  rels are identified uniquely by a pair of specs, stating that there
+  exists a unidirectional relation from values conforming to
+  `from-spec` to values conforming to `to-spec`. This relation has an
+  inverse, which maps values of `to-spec` back to the values of
+  `from-spec` which projected to them.
+
+  The rel is determined by the `to-fn` which projects values
+  conforming to the `from-spec` to values conforming to
+  `to-spec`. `to-fn` MUST be a pure function.
 
   When inserting with indices, all `to-spec` instances will be
   inserted into their corresponding tables.
@@ -260,56 +459,127 @@
 
   The `to-spec` MAY NEVER name a \"record\" shelf. `to-spec` must be a
   \"value\" shelf."
-  {:categories #{::rel}}
+  {:categories #{::rel}
+   :stability  :stability/stable
+   :added      "0.0.0"}
   [schema [from-spec to-spec :as rel-id] to-fn]
   (-> schema
       (assoc-in [:rels rel-id]
                 {:type  ::rel
                  :to-fn to-fn})
       (assoc-in [:rels [to-spec from-spec]]
-                {:type  ::alias
-                 :to rel-id})
+                {:type ::alias
+                 :to   rel-id})
       (update-in [:specs from-spec :rels]
                  (fnil conj #{}) rel-id)
       (update-in [:specs to-spec :rels]
                  (fnil conj #{}) rel-id)))
 
-(defmulti enumerate-rels
-  "Enumerates all the known rels by ID (their `[from-spec to-spec]` pair).
+(s/fdef has-rel?
+        :args (s/cat :schema ::schema
+                     :rel-id ::rel-id
+                     :to-fn ifn?)
+        :ret boolean?)
 
-  Shelves must implement this method."
+(defn has-rel?
+  "True if and only if both specs in the named rel, and the named rel exist in the schema."
   {:categories #{::rel}
+   :stability  :stability/stable
+   :added      "0.0.0"}
+  [schema [from-spec to-spec :as rel-id]]
+  (and (has-spec? schema from-spec)
+       (has-spec? schema to-spec)
+       (-> schema :rels (contains? rel-id))))
+
+(s/fdef is-alias?
+        :args (s/cat :schema ::schema
+                     :rel-id ::rel-id
+                     :to-fn ifn?)
+        :ret boolean?)
+
+(defn is-alias?
+  "True if and only if the schema has the relation (`#'has-rel?`) and the relation is an alias."
+  {:categories #{::rel}
+   :stability  :stability/stable
+   :added      "0.0.0"}
+  [schema rel-id]
+  (and (has-rel? schema rel-id)
+       (= ::alias (-> schema :rels (clojure.core/get rel-id) :type))))
+
+(s/fdef resolve-alias
+        :args (s/cat :schema ::schema
+                     :rel-id ::rel-id
+                     :to-fn ifn?)
+        :ret boolean?)
+
+(defn resolve-alias
+  "When the schema has a rel (`#'has-rel?`) and it is an
+  alias (`#'is-alias?`) resolve it, returning the directed rel it
+  aliases. Otherwise return the rel."
+  {:categories #{::rel}
+   :stability  :stability/stable
+   :added      "0.0.0"}
+  [schema rel-id]
+  (if (is-alias? schema rel-id)
+    (recur schema (-> schema :rels (clojure.core/get rel-id) :to))
+    rel-id))
+
+(defmulti enumerate-rels
+  "Enumerates all the known rels by ID (their `[from-spec to-spec]` pair). Includes aliases.
+
+  Shelves may provide alternate implementation of this method."
+  {:categories #{::rel}
+   :stability  :stability/stable
+   :added      "0.0.0"
    :arglists   '([conn])}
   #'dx)
+
+(defmethod enumerate-rels :default [conn]
+  (-> conn schema :rels keys))
 
 (defmulti enumerate-rel
   "Enumerates the `(from-id to-id)` pairs of the given rel(ation).
 
-  Shelves must implement this method."
+  Shelves must implement this method.
+
+  By default throws `me.arrdem.UnimplementedOperationException`."
   {:categories #{::rel}
+   :stability  :stability/stable
+   :added      "0.0.0"
    :arglists   '([conn rel-id])}
   #'dx)
 
+(required! enumerate-rel)
+
 (defmulti relate-by-id
   "Given a rel(ation) and the ID of an record of the from-rel spec,
-  return a seq of the IDs of records it relates to.
+  return a seq of the IDs of records it relates to. If the given ID
+  does not exist on the left side of the given relation, an empty seq
+  must be produced.
 
-  By default uses [`#'enumerate-rel`](#enumerate-rel) to do a full rel scan.
+  If the given ID does not exist on the left side of the given
+  relation, an empty seq must be produced.
+
+  Note that if the rel `[a b]` was created with `#'spec-rel`, the rel
+  `[b a]` also exists and is the complement of mapping from `a`s to
+  `b`s defined by `[a b]`.
+
+  By default uses [`#'enumerate-rel`](#enumerate-rel) to do a full scan
+  of the pairs constituting this relation.
 
   Shelves may provide more efficient implementations of this method."
   {:categories #{::rel}
-   :arglists   '([conn rel-id spec id])
-   :unstable   true}
+   :stability  :stability/unstable
+   :added      "0.0.0"
+   :arglists   '([conn rel-id spec id])}
   #'dx)
 
-(defmethod relate-by-id :default [conn rel-id id]
-  (let [[filter-fn map-fn] (comp (if (= spec (first rel-id))
-                                   [first second]
-                                   [second first])
-                                 #{id})]
-    (->> (enumerate-rel conn rel-id)
-         (filter filter-fn)
-         (map map-fn))))
+(defmethod relate-by-id :default [conn [from-spec to-spec :as rel-id] id]
+  (let [real-rel-id (resolve-alias (schema conn) rel-id)
+        f           (if (= rel-id real-rel-id)
+                      #(when (= id (first %)) (second %))
+                      #(when (= id (second %)) (first %)))]
+    (keep f (enumerate-rel conn real-rel-id))))
 
 (defmulti relate-by-value
   "Given a rel(ation) and a value conforming to the left side of the relation,
@@ -320,15 +590,14 @@
 
   Shelves may provide more efficient implementations of this method."
   {:categories #{::rel}
-   :arglists   '([conn rel-id spec id])
-   :unstable   true}
+   :stability  :stability/unstable
+   :added      "0.0.0"
+   :arglists   '([conn rel-id spec id])}
   #'dx)
 
-(defn schema->rels
-  "Helper used for converting a schema record to a set of rel(ation)s for storage."
-  {:categories #{::rel}}
-  [schema]
-  (-> schema :rels keys set))
+(defmethod relate-by-value :default [conn [from-spec to-spec :as rel-id] val]
+  {:pre [(is-value? (schema conn) from-spec)]}
+  (relate-by-id conn rel-id (id-for-record (schema conn) val)))
 
 (defn check-schema
   "Helper used for validating that a schema, being a collection of specs
@@ -338,7 +607,9 @@
   Enforces that Value specs cannot rel to Record specs. Enforces that
   all specs for all defined rels exist. Returns a sequence of errors,
   or nil if validation is successful."
-  {:categories #{:schema}}
+  {:categories #{:schema}
+   :stability  :stability/stable
+   :added      "0.0.0"}
   [{:keys [specs rels] :as schema}]
   (-> (concat (mapcat (fn [[spec-id {spec-is-record? :record? spec-rels :rels}]]
                         (when-not spec-is-record?

--- a/src/main/clj/shelving/core.clj
+++ b/src/main/clj/shelving/core.clj
@@ -12,11 +12,12 @@
   {:authors ["Reid \"arrdem\" McKenzie <me@arrdem.com>"]
    :license "Eclipse Public License 1.0"
    :added   "0.1.0"}
-  (:refer-clojure :exclude [flush get]) 
+  (:refer-clojure :exclude [flush get])
   (:import [java.util UUID]
            [java.security MessageDigest]
            [java.nio ByteBuffer])
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.walk :refer [postwalk]]
+            [clojure.spec.alpha :as s]))
 
 ;; Intentional interface for shelves
 ;;--------------------------------------------------------------------------------------------------
@@ -24,19 +25,26 @@
   "Opens a shelf for reading or writing.
 
   Shelves must implement this method."
+  {:categories #{::basic}
+   :arglists   '([config])}
   :type)
 
 (defmulti flush
   "Flushes (commits) an open shelf.
 
   Shelves must implement this method."
+  {:categories #{::basic}
+   :arglists   '([conn])}
   :type)
 
 (defmulti close
   "Closes an open shelf.
 
   Shelves may implement this method.
+
   By default just flushes."
+  {:categories #{::basic}
+   :arglists   '([conn])}
   :type)
 
 (defmethod close :default [t]
@@ -54,102 +62,297 @@
   "Fetches a record from a shelf by its spec and ID.
 
   Shelves must implement this method."
-  {:arglists '([conn spec record-id])}
+  {:categories #{::basic}
+   :arglists   '([conn spec record-id])}
   #'dx)
 
 (defmulti put
-  "Enters a record into a shelf by its spec, returning its ID.
+  "Enters a record into a shelf according to its spec in the schema,
+  inserting substructures and updating all relevant rel(ation)s.
 
-  If an ID is provided, the record will be upserted to that ID.
+  For shelves storing \"records\" not \"values\", the `id` parameter
+  may be used to either control the ID of the record, say for
+  achieving an upsert.
 
-  Shelves must implement this method.
-  Shelves are not required to flush after a put."
-  {:arglists '([conn spec record]
-               [conn spec record-id record])}
+  It is an error to specify the ID when inserting into a \"value\" shelf.
+
+  Shelves must implement this method."
+  {:categories #{::basic}
+   :arglists   '([conn spec val]
+                 [conn spec id val])}
   #'dx)
 
 (defmulti enumerate-specs
   "Enumerates all the known specs.
 
   Shelves must implement this method."
-  {:arglists '([conn])}
+  {:categories #{::schema}
+   :arglists   '([conn])}
   #'dx)
 
-(defmulti enumerate-records
+(defmulti enumerate-spec
   "Enumerates all the known records of a spec by UUID.
 
   Shelves must implement this method."
-  {:arglists '([conn spec])}
+  {:categories #{::schema}
+   :arglists   '([conn spec])}
   #'dx)
 
 ;; ID tools
 ;;--------------------------------------------------------------------------------------------------
-(defn random-uuid [& _]
+(defn random-uuid
+  "Returns a random UUID."
+  {:categories #{::util}}
+  [_]
   (UUID/randomUUID))
 
-(defn texts->sha-uuid
-  "Accepts a number of texts (strings), and computes a UUID by
-  truncating their hash to a UUID's 128bi.
+(defn digest->uuid
+  "Takes the first 16b of a `byte[]` as a 1228bi UUID.
 
-  Internally uses the SHA-256sum algorithm."
-  [& texts]
-  (let [digester (MessageDigest/getInstance "SHA-256")]
-    (locking digester
-      (.reset digester)
-      (doseq [text texts]
-        (.update digester (.getBytes (str text) "UTF-8")))
-      (let [arr (.digest digester)]
-        (UUID.
-         (.getLong
-          (doto (ByteBuffer/allocate (inc Long/BYTES))
-            (.put arr 0 8)
-            (.flip)))
-         (.getLong
-          (doto (ByteBuffer/allocate (inc Long/BYTES))
-            (.put arr 8 8)
-            (.flip))))))))
+  An `IndexOutOfBoundsException` will probably be thrown if the
+  `byte[]` is too small."
+  {:categories #{::util}}
+  [digest]
+  (let [buff (ByteBuffer/wrap digest)]
+    (UUID.
+     (.getLong buff 0)
+     (.getLong buff 1))))
+
+(defn content-hash
+  "A generic Clojure content hash based on using
+  `#'clojure.walk/postwalk` to accumulate hash values from
+  substructures.
+
+  For general Objects, takes the `java.lang.Object/hashCode` for each
+  object in postwalk's order. Strings however are fully digested as
+  UTF-8 bytes.
+
+  The precise hash used may be configured, but must be of at least
+  128bi in length as the first 128bi are converted to a UUID, which is
+  returned."
+  {:categories #{::util}}
+  ([val]
+   (content-hash "SHA-256" val))
+  ([digest-name val]
+   (let [digester  (MessageDigest/getInstance digest-name)
+         buff      (ByteBuffer/allocate (inc Integer/BYTES))
+         add-hash! (fn [o]
+                     (when o
+                       (cond (string? o)
+                             (.update digester (.getBytes o "UTF-8"))
+                             :else
+                             (do (.putInt buff 0 (hash o))
+                                 (.update digester (.array buff))))
+                       nil))]
+     (postwalk (fn [o] (add-hash! o) o) val)
+     (digest->uuid (.digest digester)))))
 
 ;; Intentional interface for schemas
 ;;--------------------------------------------------------------------------------------------------
-(def empty-schema
-  "The empty Shelving schema.
+(def ^{:doc "The empty Shelving schema.
 
   Should be used as the basis for all user-defined schemas."
+       :categories #{::schema}}
+  empty-schema
   {:type  ::schema
    :specs {}})
 
-(defn shelf-spec
-  "Enters a spec type into a schema, returning a new schema.
-
-  Data to be persisted must have a \"primary key\", being an element
-  which is considered to uniquely name a record. Multiple writes with
-  a single primary key will collide and the second one wins."
-  [schema spec id-fn & {:as opts}]
-  {:pre [(keyword? spec)
-         (ifn? id-fn)]}
-  (when (not-empty opts)
-    (binding [*out* *err*]
-      (println "Warning: shelf-schema got ignored opts" opts)))
-  (assoc-in schema [:specs spec]
-            {:type  ::spec
-             :id-fn id-fn}))
+(defn ^:private shelf-spec*
+  "Implementation detail of record-spec and value-spec."
+  [schema spec record? id-fn]
+  (update-in schema [:specs spec]
+             merge {:type    ::spec
+                    :record? record?
+                    :id-fn   id-fn
+                    :rels    #{}}))
 
 (defn has-spec?
   "Helper used for preconditions."
+  {:categories #{::schema}}
   [schema spec]
   (boolean (some-> schema :specs spec)))
 
-(defn id-for-record
-  "Function of a record which computes its ID."
-  [schema spec record]
+(defn is-value?
+  "True if and only if the spec exists and is a `:value` spec."
+  {:categories #{::schema}}
+  [schema spec]
+  (boolean (some-> schema :specs spec :record? not)))
+
+(defn value-spec
+  "Enters a new \"value\" spec into a schema, returning a new schema.
+
+  Values are addressed by a content hash derived ID, are unique and
+  cannot be deleted or updated.
+
+  Values may be related to other values via schema
+  rel(ation)s. Records may relate to values, but values cannot relate
+  to records except through reverse lookup on a record to value
+  relation."
+  {:categories #{::schema}}
+  [schema spec & {:as opts}]
+  {:pre  [(keyword? spec)
+          (namespace spec)
+          (name spec)
+          (not (has-spec? schema spec))]
+   :post [(has-spec? % spec)
+          (is-value? % spec)]}
+  (when (not-empty opts)
+    (binding [*out* *err*]
+      (println "Warning: value-spec got ignored opts" opts)))
+  (shelf-spec* schema spec false content-hash))
+
+(defn is-record?
+  "True if and only if the spec exists and is a record spec."
+  {:categories #{::schema}}
+  [schema spec]
+  (boolean (some-> schema :specs spec :record?)))
+
+(defn record-spec
+  "Enters a new \"record\" spec into a schema, returning a new schema.
+
+  Records have traditional place semantics and are identified by
+  randomly generated IDs, rather than the structural semantics
+  ascribed to values."
+  {:categories #{::schema}}
+  [schema spec & {:as opts}]
+  {:pre  [(keyword? spec)
+          (namespace spec)
+          (name spec)
+          (not (has-spec? schema spec))]
+   :post [(has-spec? % spec)
+          (is-record? % spec)]}
+  (when (not-empty opts)
+    (binding [*out* *err*]
+      (println "Warning: record-spec got ignored opts" opts)))
+  (shelf-spec* schema spec true random-uuid))
+
+(defn id-for-val
+  "Returns the `val`'s identifying UUID according to the spec's schema entry."
+  {:categories #{::schema}}
+  [schema spec val]
   {:pre [(has-spec? schema spec)]}
   (let [key-fn (-> schema
                    :specs
                    (clojure.core/get spec)
-                   (clojure.core/get :id-fn random-uuid))] 
-    (key-fn record)))
+                   (clojure.core/get :id-fn random-uuid))]
+    (key-fn val)))
 
 (defn schema->specs
   "Helper used for converting a schema record to a set of specs for storage."
+  {:categories #{::schema}}
   [schema]
   (-> schema :specs keys set))
+
+;; Relations
+;;--------------------------------------------------------------------------------------------------
+(defn spec-rel
+  "Enters a rel(ation) into a schema, returning a new schema which will
+  maintain that rel.
+
+  rels are identified uniquely by a pair of specs, and the relation is
+  determined by the to-fn which projects instances of the `from-spec`
+  to instances of the `to-spec`. `to-fn` MUST be a pure function.
+
+  When inserting with indices, all `to-spec` instances will be
+  inserted into their corresponding tables.
+
+  At insertion time, the `to-spec` must exist as a supported shelf.
+
+  The `to-spec` MAY NEVER name a \"record\" shelf. `to-spec` must be a
+  \"value\" shelf."
+  {:categories #{::rel}}
+  [schema [from-spec to-spec :as rel-id] to-fn]
+  (-> schema
+      (assoc-in [:rels rel-id]
+                {:type  ::rel
+                 :to-fn to-fn})
+      (assoc-in [:rels [to-spec from-spec]]
+                {:type  ::alias
+                 :to rel-id})
+      (update-in [:specs from-spec :rels]
+                 (fnil conj #{}) rel-id)
+      (update-in [:specs to-spec :rels]
+                 (fnil conj #{}) rel-id)))
+
+(defmulti enumerate-rels
+  "Enumerates all the known rels by ID (their `[from-spec to-spec]` pair).
+
+  Shelves must implement this method."
+  {:categories #{::rel}
+   :arglists   '([conn])}
+  #'dx)
+
+(defmulti enumerate-rel
+  "Enumerates the `(from-id to-id)` pairs of the given rel(ation).
+
+  Shelves must implement this method."
+  {:categories #{::rel}
+   :arglists   '([conn rel-id])}
+  #'dx)
+
+(defmulti relate-by-id
+  "Given a rel(ation) and the ID of an record of the from-rel spec,
+  return a seq of the IDs of records it relates to.
+
+  By default uses [`#'enumerate-rel`](#enumerate-rel) to do a full rel scan.
+
+  Shelves may provide more efficient implementations of this method."
+  {:categories #{::rel}
+   :arglists   '([conn rel-id spec id])
+   :unstable   true}
+  #'dx)
+
+(defmethod relate-by-id :default [conn rel-id id]
+  (let [[filter-fn map-fn] (comp (if (= spec (first rel-id))
+                                   [first second]
+                                   [second first])
+                                 #{id})]
+    (->> (enumerate-rel conn rel-id)
+         (filter filter-fn)
+         (map map-fn))))
+
+(defmulti relate-by-value
+  "Given a rel(ation) and a value conforming to the left side of the relation,
+  return a seq of the IDs of records on the right side of the
+  relation (if any) it relates to.
+
+  By default uses [`#'enumerate-rel`](#enumerate-rel) to do a full rel scan.
+
+  Shelves may provide more efficient implementations of this method."
+  {:categories #{::rel}
+   :arglists   '([conn rel-id spec id])
+   :unstable   true}
+  #'dx)
+
+(defn schema->rels
+  "Helper used for converting a schema record to a set of rel(ation)s for storage."
+  {:categories #{::rel}}
+  [schema]
+  (-> schema :rels keys set))
+
+(defn check-schema
+  "Helper used for validating that a schema, being a collection of specs
+  and rel(ation)s, is legal with respect to the various restrictions
+  imposed by the current version of shelving.
+
+  Enforces that Value specs cannot rel to Record specs. Enforces that
+  all specs for all defined rels exist. Returns a sequence of errors,
+  or nil if validation is successful."
+  {:categories #{:schema}}
+  [{:keys [specs rels] :as schema}]
+  (-> (concat (mapcat (fn [[spec-id {spec-is-record? :record? spec-rels :rels}]]
+                        (when-not spec-is-record?
+                          (keep (fn [[from-spec to-spec]]
+                                  (when (and (= from-spec spec-id)
+                                             (is-record? schema to-spec))
+                                    (format "Illegal relation - cannot relate value spec %s to record spec %s"
+                                            from-spec to-spec)))
+                                spec-rels)))
+                      specs)
+              (-> (mapcat (fn [specs]
+                            (keep #(when-not (has-spec? schema %)
+                                     (format "Illegal relation %s - unknown spec %s" specs %))
+                                  specs))
+                          (keys rels))
+                  set seq))
+      seq))

--- a/src/main/clj/shelving/trivial_edn.clj
+++ b/src/main/clj/shelving/trivial_edn.clj
@@ -3,20 +3,24 @@
   {:authors ["Reid \"arrdem\" McKenzie <me@arrdem.com>"]
    :license "Eclipse Public License 1.0"
    :added   "0.1.0"}
-  (:require [shelving.core :as sh] 
+  (:require [shelving.core :as sh]
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
             [clojure.set :refer [superset?]]))
 
 ;; Configs open into shelves
-(defmethod sh/open ::config [{:keys [path schema] :as s}]
-  (let [state            (-> (if (.exists (io/file path))
+(defmethod sh/open ::config [{:keys [path schema load] :as s}]
+  (when-not load
+    (binding [*out* *err*]
+      (println "Warning: opening connection without trying to load existing data set!")))
+  (let [state            (-> (if (and load
+                                      (.exists (io/file path)))
                                (-> path
                                    io/reader
                                    java.io.PushbackReader.
                                    edn/read
-                                   ((fn [v] (assert (map? v)) v))) 
+                                   ((fn [v] (assert (map? v)) v)))
                                {})
                              atom)
         conn             (-> s
@@ -35,7 +39,7 @@
 
     ;; Validate any loaded data
     (doseq [spec (sh/enumerate-specs conn)
-            id   (sh/enumerate-records conn spec)
+            id   (sh/enumerate-spec conn spec)
             :let [record (sh/get conn spec id)]]
       (if-not (s/valid? spec record)
         (throw (ex-info "Failed to validate record!"
@@ -66,31 +70,118 @@
 (defmethod sh/get ::shelf [{:keys [shelving.trivial-edn/state]} spec record-id]
   (-> @state (get :records) (get spec) (get record-id)))
 
+(declare ^:private put*)
+
+(defn rel-invalidate-record*
+  "Relation implementation detail.
+
+  Returns a new rel map, with the given record-id's entries purged."
+  [[from-spec to-spec :as rel-id] rel-map record-id]
+  (let [tos (-> rel-map (get from-spec) (get record-id))]
+    (as-> rel-map %
+      (update % from-spec dissoc record-id)
+      (update % :pairs #(remove (comp #{record-id} first) %))
+      (reduce (fn [% to]
+                (update-in % [to-spec to] #(remove #{record-id} %)))
+              % tos))))
+
+(defn rel-invalidate-record
+  "Relation implementation detail.
+
+  Removes all pairs containing the given `record-id` from all rel tables."
+  [rels schema spec record-id]
+  (->> (for [[[from-spec to-spec :as rel-id] rel-map] rels
+             :when                                    (or (= spec from-spec)
+                                                          (= spec to-spec))]
+         [rel-id (rel-invalidate-record* rel-id rel-map record-id)])
+       (into {})))
+
+(defn rel-index-record
+  "Relation implementation detail.
+
+  Updates all rel tables to reflect the new record with the given ID."
+  [state schema spec record record-id]
+  (let [rels-to-update (for [[[from-spec to-spec :as rel-id] rel-spec] (:rels schema)
+                             :when                                     (= spec from-spec)]
+                         [rel-id rel-spec])]
+    (reduce (fn [state [[from-spec to-spec :as rel-id] {:keys [to-fn] :as rel}]]
+              (let [{:keys [id-fn] :as to-schema} (get-in schema [:specs to-spec])
+                    to-record                     (to-fn record)
+                    to-id                         (id-fn to-record)]
+                (-> state
+                    (put* schema to-spec to-id to-record)
+                    (update-in [:rels rel-id :pairs] conj [record-id to-id])
+                    (update-in [:rels rel-id to-spec to-id] conj record-id)
+                    (update-in [:rels rel-id from-spec record-id] conj to-id))))
+            state rels-to-update)))
+
+;; FIXME (arrdem 2018-02-04):
+;;   Can I optimize this in the case of inserting a value? Possibilities:
+;;   - No rels to invalidate
+;;   - May not need to do the insert at all
+;;   - Index building could be batched
+(defn- put*
+  "Implementation detail.
+
+  Backs `#'sh/put`, providing the actual recursive write logic."
+  [state schema spec record-id record]
+  (assert (uuid? record-id))
+  (assert (sh/has-spec? schema spec))
+  (assert (s/valid? spec record))
+  (-> state
+      (update :rels rel-invalidate-record schema spec record-id)
+      (assoc-in [:records spec record-id] record)
+      (rel-index-record schema spec record record-id)))
+
+(defn- put-record*
+  ([{:keys [schema] :as conn} spec val]
+   (put-record* conn spec (sh/id-for-val schema spec val) val))
+  ([{:keys [shelving.trivial-edn/state schema] :as conn} spec id val]
+   (swap! state put* schema spec id val)
+   id))
+
+(defn- put-val* [{:keys [schema] :as conn} spec val]
+  (put-record* conn spec (sh/id-for-val schema spec val) val))
+
 (defmethod sh/put ::shelf
-  ([{:keys [schema] :as conn} spec record]1
-   (sh/put conn spec (sh/id-for-record schema spec record) record))
-  ([{:keys [shelving.trivial-edn/state schema flush-after-write]} spec record-id record]
-   (let [state-val @state]
-     (dosync
-      (assert (uuid? record-id))
-      (assert (sh/has-spec? schema spec))
-      (assert (s/valid? spec record))
-      (swap! state assoc-in [:records spec record-id] record)))
-   (when flush-after-write
-     (flush state))
-   record-id))
+  ([{:keys [schema flush-after-write] :as conn} spec val]
+   (let [id (if (sh/is-value? schema spec)
+              (put-val* conn spec val)
+              (put-record* conn spec val))]
+     (when flush-after-write
+       (sh/flush conn))
+     id))
+  ([{:keys [schema flush-after-write] :as conn} spec id val]
+   (let [id (if (sh/is-record? schema spec)
+              (put-record* conn spec id val)
+              (throw (UnsupportedOperationException.
+                      (format "Cannot perform an upsert to value spec %s" spec))))]
+     (when flush-after-write
+       (sh/flush conn))
+     id)))
 
 (defmethod sh/enumerate-specs ::shelf [{:keys [schema shelving.trivial-edn/state]}]
-  (-> @state (get :schema) seq))
+  (some-> schema :specs keys))
 
-(defmethod sh/enumerate-records ::shelf [{:keys [schema shelving.trivial-edn/state]} spec]
-  (-> @state (get :records) (get spec) keys))
+(defmethod sh/enumerate-spec ::shelf [{:keys [shelving.trivial-edn/state]} spec]
+  (some-> @state (get :records) (get spec) keys))
+
+(defmethod sh/enumerate-rels ::shelf [{:keys [shelving.trivial-edn/state]}]
+  (some-> @state (get :rels) keys))
+
+(defmethod sh/enumerate-rel ::shelf [{:keys [shelving.trivial-edn/state]} rel]
+  (some-> @state (get :rels) (get rel) (get :pairs) seq))
+
+(defmethod sh/get-from-rel-by-id ::shelf [{:keys [shelving.trivial-edn/state]} rel spec id]
+  (some-> @state (get :rels) (get rel) (get spec) (get id) seq))
 
 (defn ->TrivialEdnShelf
   "Configures a (trivial) EDN shelf which can be opened for reading and writing."
-  [schema path & {:keys [flush-after-write]
-                  :or   {flush-after-write false}}]
+  [schema path & {:keys [flush-after-write load]
+                  :or   {flush-after-write false
+                         load              true}}]
   {:type              ::config
    :schema            schema
    :path              path
-   :flush-after-write flush-after-write})
+   :flush-after-write flush-after-write
+   :load              true})

--- a/src/main/jvm/me/arrdem/UnimplementedOperationException.java
+++ b/src/main/jvm/me/arrdem/UnimplementedOperationException.java
@@ -1,0 +1,20 @@
+package me.arrdem;
+
+/**
+ * An exception for when operations have not been implemented.
+ *
+ * Parallel to UnsupportedOperationException, but for required operations.
+ */
+public class UnimplementedOperationException extends Exception {
+    public UnimplementedOperationException() {
+        super();
+    }
+
+    public UnimplementedOperationException(String message) {
+        super(message);
+    }
+
+    public UnimplementedOperationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/clj/doc_test.clj
+++ b/src/test/clj/doc_test.clj
@@ -1,0 +1,78 @@
+(ns doc-test
+  (:require [clojure.test :as t]
+            [clojure.java.shell :refer [sh]]
+            [clojure.string :as str]
+            [clojure.java.io :as io])
+  (:import [java.io StringReader]))
+
+;; Literature:
+;;   https://github.com/cldwalker/lein-spell/blob/master/src/leiningen/spell/core.clj
+;;   http://aspell.net/0.50-doc/man-html/6_Writing.html#pipe
+
+(def aspell-pattern
+  #"& (?<word>\w+) (?<offset>\d+) (?<count>\d+): (?<alternatives>.*?)$")
+
+(defn parse-aspell [text]
+  (->> (str/split text #"\n")
+       (keep (fn [line]
+               (let [matcher (re-matcher aspell-pattern line)]
+                 (when (.matches matcher)
+                   {:type        :aspell/error
+                    :word        (.group matcher "word")
+                    :offset      (Long/parseLong (.group matcher "offset"))
+                    :count       (Long/parseLong (.group matcher "count"))
+                    :corrections (str/split (.group matcher "alternatives") #", ")}))))))
+
+(defn aspell [reader]
+  (let [{:keys [exit err out]} (sh "aspell" "-a" "--ignore=3" "list" :in reader)]
+    (when-not (and (= 0 out)
+                   (or (not-empty err)
+                       (not-empty out)))
+      (seq (parse-aspell out)))))
+
+(defn format-error [{:keys [word corrections]}]
+  (format "Unknown word %s%s" word
+          (when corrections (format " possible corrections: %s" (str/join " " (take 3 corrections))))))
+
+(defn format-spelling-errors [entity errors]
+  (format "Error checking spelling of %s:\n%s" entity
+          (->> errors
+               (map #(str "- " (format-error %)))
+               (str/join "\n"))))
+
+#_(t/deftest test-docstring-spelling
+    (doseq [ns        (all-ns)
+            [sym var] (ns-publics ns)
+            :when     (and (var? var)
+                           (.contains (str var) "shelving")
+                           (not (.contains (str var) "-test")))
+            :let      [{:keys [doc] :as meta} (meta var)]]
+      (t/is doc (format "Var %s is public and doesn't have a docstring!" var))
+      (when doc
+        (let [spell-errors (aspell (StringReader. doc))]
+          (when-not (empty? spell-errors)
+            (println
+             (format-spelling-errors var spell-errors)))))))
+
+#_(t/deftest test-markdown-spelling
+    (doseq [f     (file-seq (io/file "."))
+            :when (or (.endsWith (str (.toURI f)) ".md")
+                      (.endsWith (str (.toURI f)) ".markdown"))]
+      (let [spell-errors (aspell (io/reader f))]
+        (t/is (empty? spell-errors)
+              (format-spelling-errors f spell-errors)))))
+
+(t/deftest test-markdown-vars
+  (t/testing "Do we reference vars that don't exist? Indicates stale docs."
+    (doseq [f           (file-seq (io/file "."))
+            :when       (or (.endsWith (str (.toURI f)) ".md")
+                            (.endsWith (str (.toURI f)) ".markdown"))
+            :let        [buff (slurp (io/reader f))
+                         symbols (re-seq #"(?:\n## )(?<namespace>[^/]*?)/(?<name>\S+)" buff)]
+            [_ ns name] symbols
+            :when       (.contains ns "shelving.")
+            :let        [the-sym (symbol ns name)]]
+      (require (symbol (namespace the-sym)))
+      (t/is (find-var the-sym)
+            (format "In file %s, couldn't find mentioned var %s/%s" f ns name)))))
+

--- a/src/test/clj/doc_test.clj
+++ b/src/test/clj/doc_test.clj
@@ -40,6 +40,33 @@
                (map #(str "- " (format-error %)))
                (str/join "\n"))))
 
+(t/deftest test-docstring-presence
+  (doseq [ns        (all-ns)
+          [sym var] (ns-publics ns)
+          :when     (and (var? var)
+                         (.contains (str var) "shelving")
+                         (not (.contains (str var) "-test")))
+          :let      [{:keys [doc] :as meta} (meta var)]]
+    (t/is doc (format "Var %s is public and doesn't have a docstring!" var))))
+
+(t/deftest test-categories-presence
+  (doseq [ns        (all-ns)
+          [sym var] (ns-publics ns)
+          :when     (and (var? var)
+                         (.contains (str var) "shelving")
+                         (not (.contains (str var) "-test")))
+          :let      [{:keys [categories] :as meta} (meta var)]]
+    (t/is categories (format "Var %s is public and doesn't have a categorization!" var))))
+
+(t/deftest test-added-presence
+  (doseq [ns        (all-ns)
+          [sym var] (ns-publics ns)
+          :when     (and (var? var)
+                         (.contains (str var) "shelving")
+                         (not (.contains (str var) "-test")))
+          :let      [{:keys [added] :as meta} (meta var)]]
+    (t/is added (format "Var %s is public and doesn't have a added!" var))))
+
 #_(t/deftest test-docstring-spelling
     (doseq [ns        (all-ns)
             [sym var] (ns-publics ns)
@@ -68,7 +95,7 @@
             :when       (or (.endsWith (str (.toURI f)) ".md")
                             (.endsWith (str (.toURI f)) ".markdown"))
             :let        [buff (slurp (io/reader f))
-                         symbols (re-seq #"(?:\n## )(?<namespace>[^/]*?)/(?<name>\S+)" buff)]
+                         symbols (re-seq #"(?:\n## \[)(?<namespace>[^/]*?)/(?<name>[^\]]+)\]" buff)]
             [_ ns name] symbols
             :when       (.contains ns "shelving.")
             :let        [the-sym (symbol ns name)]]

--- a/src/test/clj/grimoire_test.clj
+++ b/src/test/clj/grimoire_test.clj
@@ -1,0 +1,33 @@
+(ns grimoire-test
+  (:require [clojure.test :as t]
+            [shelving.core :as shelving]
+            [shelving.trivial-edn :as ts]
+            [grimoire :refer :all :as g]))
+
+(def *conn
+  (-> (ts/->TrivialEdnShelf schema "target/grim.edn"
+                            :load false)
+      (shelving/open)))
+
+(def clj-160
+  (->mvn-pkg "org.clojure" "clojure" "1.6.0"))
+
+(def clj-180
+  (->mvn-pkg "org.clojure" "clojure" "1.8.0"))
+
+(def clj-160-clojure-core
+  (->namespace clj-160 "clj" "clojure.core"))
+
+(def clj-180-clojure-core
+  (->namespace clj-180 "clj" "clojure.core"))
+
+(shelving/flush *conn)
+
+(t/deftest test-indexing
+  (let [;; write some CLJ versions
+        clj-160-id (shelving/put *conn ::g/package clj-160)
+        clj-180-id (shelving/put *conn ::g/package clj-180)
+
+        ;; Write some core versions
+        core-160-id (shelving/put *conn ::g/entity clj-160-clojure-core)
+        core-180-id (shelving/put *conn ::g/entity clj-180-clojure-core)]))

--- a/src/test/clj/shelving/common_test.clj
+++ b/src/test/clj/shelving/common_test.clj
@@ -2,42 +2,132 @@
   (:require [shelving.core :as sh]
             [shelving.trivial-edn :refer [->TrivialEdnShelf]]
             [clojure.test :as t]
-            [clojure.test.check :as tc] 
+            [clojure.test.check :as tc]
+            [clojure.test.check.properties :as prop]
             [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as sgen]
-            [clojure.test.check.clojure-test :refer [defspec]]))
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.string :as str]))
 
 (s/def ::foo string?)
+(s/def ::bar string?)
+(s/def ::baz
+  (s/keys :req-un [::foo ::bar]))
 
-(defn run-example
+(defn put-get-enumerate-example-tests [->cfg]
+  (let [foo-gen (s/gen ::foo)
+        baz-gen (s/gen ::baz)
+        schema  (-> sh/empty-schema
+                    (sh/value-spec ::foo)
+                    (sh/record-spec ::baz))]
+
+    (t/testing "Checking schema for errors"
+      (let [schema-errors (sh/check-schema schema)]
+        (t/is (not schema-errors)
+              (str/join "\n" schema-errors))))
+
+    (t/testing "Testing connection ops"
+      (let [cfg  (->cfg schema)
+            conn (sh/open cfg)]
+
+        (t/testing "Conn has correct spec/schema information"
+          (t/is (= '(::foo ::baz)
+                   (sh/enumerate-specs conn))))
+
+        (t/testing "Testing put/get on values"
+          (let [v1 (sgen/generate foo-gen)
+                r1 (sh/put conn ::foo v1)
+                v2 (sgen/generate foo-gen)
+                r2 (sh/put conn ::foo v2)]
+            
+            (t/is (= v1 (sh/get conn ::foo r1)))
+            (t/is (= v2 (sh/get conn ::foo r2)))
+            (t/is (= (list r1 r2) (sh/enumerate-spec conn ::foo)))
+            (t/is (thrown? UnsupportedOperationException
+                           (sh/put conn ::foo r1 (sgen/generate foo-gen))))))
+
+        (t/testing "Testing put/get on records"
+          (let [b1  (sgen/generate baz-gen)
+                b2  (sgen/generate baz-gen)
+                bi1 (sh/put conn ::baz b1)]
+            (t/is (= b1 (sh/get conn ::baz bi1)))
+            (t/is (= (list bi1) (sh/enumerate-spec conn ::baz)))
+            ;; Upserts should work
+            (sh/put conn ::baz bi1 b2)
+            (t/is (= b2 (sh/get conn ::baz bi1)))
+            (t/is (= (list bi1) (sh/enumerate-spec conn ::baz)))))))))
+
+(defn value-rel-tests [->cfg]
+  (let [foo-gen (s/gen ::foo)
+        baz-gen (s/gen ::baz)
+        schema  (-> sh/empty-schema
+                    (sh/value-spec ::foo)
+                    (sh/value-spec ::baz)
+                    (sh/spec-rel [::baz ::foo] :foo))
+        conn    (sh/open (->cfg schema))]
+    (tc/quick-check 1000
+      (prop/for-all [baz baz-gen]
+        (let [the-foo (:foo baz)
+              foo-id  (sh/put conn ::foo the-foo)
+              baz-id  (sh/put conn ::baz baz)]
+          (t/is foo-id)
+          (t/is baz-id)
+          ;; Relations are bidirectional on read, unidirectional on write.
+          (t/is (some #{foo-id} (sh/get-from-rel-by-id conn [::baz ::foo] ::baz baz-id)))
+          (t/is (some #{baz-id} (sh/get-from-rel-by-id conn [::baz ::foo] ::foo foo-id))))))))
+
+(defn record-rel-tests [->cfg]
+  (let [foo-gen (s/gen ::foo)
+        baz-gen (s/gen ::baz)
+        schema  (-> sh/empty-schema
+                    (sh/value-spec ::foo)
+                    (sh/record-spec ::baz)
+                    (sh/spec-rel [::baz ::foo] :foo))
+        conn    (sh/open (->cfg schema))]
+    (tc/quick-check 1000
+      (prop/for-all [baz  baz-gen
+                     baz' baz-gen]
+        (let [the-foo  (:foo baz)
+              the-foo' (:foo baz')
+              foo-id   (sh/put conn ::foo the-foo)
+              foo-id'  (sh/put conn ::foo the-foo')
+              baz-id   (sh/put conn ::baz baz)]
+          (t/is foo-id)
+          (t/is baz-id)
+          ;; Relations are bidirectional on read, unidirectional on write.
+          (t/is (some #(= % foo-id) (sh/get-from-rel-by-id conn [::baz ::foo] ::baz baz-id)))
+          (t/is (some #(= % baz-id) (sh/get-from-rel-by-id conn [::baz ::foo] ::foo foo-id)))
+
+          ;; Now perform a write which should invalidate the above properties
+          (sh/put conn ::baz baz-id baz')
+          ;; The old values should no longer be associated as baz has changed.
+          ;; But only if foo and foo' are distinct.
+          (when (not= the-foo the-foo')
+            (t/is (not-any? #{foo-id} (sh/get-from-rel-by-id conn [::baz ::foo] ::baz baz-id)))
+            (t/is (not-any? #{baz-id} (sh/get-from-rel-by-id conn [::baz ::foo] ::foo foo-id))))
+
+          ;; The new values should be in effect
+          (t/is (some #{foo-id'} (sh/get-from-rel-by-id conn [::baz ::foo] ::baz baz-id)))
+          (t/is (some #{baz-id}  (sh/get-from-rel-by-id conn [::baz ::foo] ::foo foo-id'))))))))
+
+(defn rel-tests [->cfg]
+  (value-rel-tests ->cfg)
+  (record-rel-tests ->cfg))
+
+#_(defn persistence-tests [->cfg]
+    (let [;; Test round-tripping
+          _    (sh/close conn)
+          conn (sh/open cfg)
+          _    (t/is (= (sh/enumerate-specs conn) '(::foo ::baz)))
+          _    (t/is (= (sh/enumerate-spec conn ::foo) (list r1 r2)))
+          _    (t/is (= v1 (sh/get conn ::foo r1)))
+          _    (t/is (= v2 (sh/get conn ::foo r2)))]))
+
+(defn common-tests
   "Takes a ctor of fn [schema] -> cfg, applies it and opens the resulting config twice.
 
   Runs the example usage session in the README against the computed config."
   [->cfg]
-  (let [foo-gen (s/gen ::foo)
-        schema  (-> sh/empty-schema
-                    ;; Using content hashing for ID generation
-                    (sh/shelf-spec ::foo sh/texts->sha-uuid))
-        cfg     (->cfg schema)
-        conn    (sh/open cfg)
-        _       (t/is (= (sh/enumerate-specs conn) '(::foo)))
-
-        v1 (sgen/generate foo-gen)
-        r1 (sh/put conn ::foo v1)
-        _  (t/is (= v1 (sh/get conn ::foo r1)))
-
-        v2 (sgen/generate foo-gen)
-        r2 (sh/put conn ::foo v2)
-        _  (t/is (= (sh/enumerate-records conn ::foo) (list r1 r2)))
-
-        v3 (sgen/generate foo-gen)
-        _  (sh/put conn ::foo r1 v3)
-        _  (t/is (= v3 (sh/get conn ::foo r1)))
-
-        ;; Test round-tripping
-        _    (sh/close conn)
-        conn (sh/open cfg)
-        _    (t/is (= (sh/enumerate-specs conn) '(::foo)))
-        _    (t/is (= (sh/enumerate-records conn ::foo) (list r1 r2)))
-        _    (t/is (= v2 (sh/get conn ::foo r2)))
-        _    (t/is (= v3 (sh/get conn ::foo r1)))]))
+  (put-get-enumerate-example-tests ->cfg)
+  (rel-tests ->cfg)
+  #_(persistence-tests ->cfg))

--- a/src/test/clj/shelving/common_test.clj
+++ b/src/test/clj/shelving/common_test.clj
@@ -39,7 +39,7 @@
                 r1 (sh/put conn ::foo v1)
                 v2 (sgen/generate foo-gen)
                 r2 (sh/put conn ::foo v2)]
-            
+
             (t/is (= v1 (sh/get conn ::foo r1)))
             (t/is (= v2 (sh/get conn ::foo r2)))
             (t/is (= (list r1 r2) (sh/enumerate-spec conn ::foo)))
@@ -72,9 +72,9 @@
               baz-id  (sh/put conn ::baz baz)]
           (t/is foo-id)
           (t/is baz-id)
-          ;; Relations are bidirectional on read, unidirectional on write.
-          (t/is (some #{foo-id} (sh/get-from-rel-by-id conn [::baz ::foo] ::baz baz-id)))
-          (t/is (some #{baz-id} (sh/get-from-rel-by-id conn [::baz ::foo] ::foo foo-id))))))))
+                        ;; Relations are bidirectional on read, unidirectional on write.
+          (t/is (some #{foo-id} (sh/relate-by-id conn [::baz ::foo] baz-id)))
+          (t/is (some #{baz-id} (sh/relate-by-id conn [::foo ::baz] foo-id))))))))
 
 (defn record-rel-tests [->cfg]
   (let [foo-gen (s/gen ::foo)
@@ -94,21 +94,21 @@
               baz-id   (sh/put conn ::baz baz)]
           (t/is foo-id)
           (t/is baz-id)
-          ;; Relations are bidirectional on read, unidirectional on write.
-          (t/is (some #(= % foo-id) (sh/get-from-rel-by-id conn [::baz ::foo] ::baz baz-id)))
-          (t/is (some #(= % baz-id) (sh/get-from-rel-by-id conn [::baz ::foo] ::foo foo-id)))
+                        ;; Relations are bidirectional on read, unidirectional on write.
+          (t/is (some #(= % foo-id) (sh/relate-by-id conn [::baz ::foo] baz-id)))
+          (t/is (some #(= % baz-id) (sh/relate-by-id conn [::foo ::baz] foo-id)))
 
-          ;; Now perform a write which should invalidate the above properties
+                        ;; Now perform a write which should invalidate the above properties
           (sh/put conn ::baz baz-id baz')
-          ;; The old values should no longer be associated as baz has changed.
-          ;; But only if foo and foo' are distinct.
+                        ;; The old values should no longer be associated as baz has changed.
+                        ;; But only if foo and foo' are distinct.
           (when (not= the-foo the-foo')
-            (t/is (not-any? #{foo-id} (sh/get-from-rel-by-id conn [::baz ::foo] ::baz baz-id)))
-            (t/is (not-any? #{baz-id} (sh/get-from-rel-by-id conn [::baz ::foo] ::foo foo-id))))
+            (t/is (not-any? #{foo-id} (sh/relate-by-id conn [::baz ::foo] baz-id)))
+            (t/is (not-any? #{baz-id} (sh/relate-by-id conn [::foo ::foo] foo-id))))
 
-          ;; The new values should be in effect
-          (t/is (some #{foo-id'} (sh/get-from-rel-by-id conn [::baz ::foo] ::baz baz-id)))
-          (t/is (some #{baz-id}  (sh/get-from-rel-by-id conn [::baz ::foo] ::foo foo-id'))))))))
+                        ;; The new values should be in effect
+          (t/is (some #{foo-id'} (sh/relate-by-id conn [::baz ::foo] baz-id)))
+          (t/is (some #{baz-id}  (sh/relate-by-id conn [::foo ::baz] foo-id'))))))))
 
 (defn rel-tests [->cfg]
   (value-rel-tests ->cfg)

--- a/src/test/clj/shelving/trivial_test.clj
+++ b/src/test/clj/shelving/trivial_test.clj
@@ -1,10 +1,10 @@
 (ns shelving.trivial-test
   (:require [clojure.test :as t]
             [shelving.trivial-edn :refer [->TrivialEdnShelf]]
-            [shelving.common-test :refer [run-example]])
+            [shelving.common-test :refer [common-tests]])
   (:import [java.io File]))
 
 (t/deftest trivial-test
   (let [f (File/createTempFile "trivial-test" ".edn")]
     (.delete f)
-    (run-example #(->TrivialEdnShelf % f))))
+    (common-tests #(->TrivialEdnShelf % f))))


### PR DESCRIPTION
Relations describe how shelves can be decomposed to substructures according to their specs, and how they should be indexed according to their substructures.

This requires reworking the original API which treated the entire shelving unit as a multi-table k/v store and recognizing that there are two kinds of access patterns we want to support - "records" and "values". Most of my design work is oriented around values in the traditional Clojure sese. Shelving is really designed to be a value store, not a record store in the traditional sense of a mutable database. Adding relations brings this contention to a head by demanding that I figure out the mechanics for building and maintaining relations.

The core of the issue is that it's possible to write to a "value" shelf just like yoou'd write to any other shelf. Upserts are the particular issue, in that they invite violations of the "value is identity" property, and can lead to transitive invalidation of other value shelves.

Solitions to this problem are:
1. To position shelving as a value store, not a record store. This means dropping upserts as a feature.
2. To define a distinction between "values" and "records", where "values" do not support upserts (or deletion in the future) and are identified by content hash while "records" do not have repeatable IDs, can be upserted (or maybe deleted) and cannot occur as targets of rels.

This changeset begins to implement the second approach, thus enabling relations on values and preserving the possibility of relations on records at the cost of some change to the basic APIs to differentiate between record shelves and value shelves explicitly.

Fixes #2 without loss of generality AFAIK