### PR TITLE
Full record decomposition

### DIFF
--- a/docs/basic.md
+++ b/docs/basic.md
@@ -45,7 +45,7 @@ Enumerates all the known specs.
 
 Shelves may provide alternate implementations of this method.
 
-### [shelving.core/put-spec](shelving/core.clj#L147)
+### [shelving.core/put-spec](shelving/core.clj#L159)
  - `(put-spec conn spec val)`
  - `(put-spec conn spec id val)`
 
@@ -59,7 +59,7 @@ It is an error to specify the ID when inserting into a "value" shelf.
 
 Shelves must implement [`#'shelving.impl/put-spec`](/docs/impl.md#shelvingimplput-spec), which backs this method.
 
-### [shelving.core/get-spec](shelving/core.clj#L174)
+### [shelving.core/get-spec](shelving/core.clj#L185)
  - `(get-spec conn spec record-id)`
  - `(get-spec conn spec record-id not-found)`
 
@@ -180,7 +180,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.core/alter-schema](shelving/core.clj#L191)
+### [shelving.core/alter-schema](shelving/core.clj#L210)
  - `(alter-schema conn f & args)`
 
 Attempts alter the schema of a live connection.

--- a/docs/basic.md
+++ b/docs/basic.md
@@ -7,14 +7,14 @@ configurations. These operations should be shared by all implementations.
 
 ## Connecting
 
-### [shelving.core/open](shelving/impl.clj#L59)
+### [shelving.core/open](shelving/impl.clj#L31)
  - `(open config)`
 
 Opens a shelf for reading or writing.
 
 Shelves must implement this method.
 
-### [shelving.core/flush](shelving/impl.clj#L71)
+### [shelving.core/flush](shelving/impl.clj#L43)
  - `(flush conn)`
 
 Flushes (commits) an open shelf.
@@ -23,7 +23,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.core/close](shelving/impl.clj#L85)
+### [shelving.core/close](shelving/impl.clj#L57)
  - `(close conn)`
 
 Closes an open shelf.
@@ -38,14 +38,14 @@ By default just flushes.
 
 
 
-### [shelving.core/enumerate-specs](shelving/impl.clj#L212)
+### [shelving.core/enumerate-specs](shelving/impl.clj#L184)
  - `(enumerate-specs conn)`
 
 Enumerates all the known specs.
 
 Shelves may provide alternate implementations of this method.
 
-### [shelving.core/put-spec](shelving/core.clj#L150)
+### [shelving.core/put-spec](shelving/core.clj#L147)
  - `(put-spec conn spec val)`
  - `(put-spec conn spec id val)`
 
@@ -59,7 +59,7 @@ It is an error to specify the ID when inserting into a "value" shelf.
 
 Shelves must implement [`#'shelving.impl/put-spec`](/docs/impl.md#shelvingimplput-spec), which backs this method.
 
-### [shelving.core/get-spec](shelving/core.clj#L177)
+### [shelving.core/get-spec](shelving/core.clj#L174)
  - `(get-spec conn spec record-id)`
  - `(get-spec conn spec record-id not-found)`
 
@@ -69,7 +69,7 @@ Recovers a record from a shelf according to spec and ID, returning the given `no
 
 Shelves must implement [`#'shelving.impl/get-spec`](/docs/impl.md#shelvingimplget-spec), which backs this method.
 
-### [shelving.core/has?](shelving/impl.clj#L138)
+### [shelving.core/has?](shelving/impl.clj#L110)
  - `(has? conn spec record-id)`
 
 Indicates whether a shelf has a record of a spec.
@@ -78,7 +78,7 @@ Returns `true` if and only if the shelf contains a record if the given spec and 
 
 Implementations may provide alternate implementations of this method.
 
-### [shelving.core/count-spec](shelving/impl.clj#L239)
+### [shelving.core/count-spec](shelving/impl.clj#L211)
  - `(count-spec conn spec)`
 
 **UNSTABLE**: This API will probably change in the future
@@ -91,7 +91,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.core/enumerate-spec](shelving/impl.clj#L225)
+### [shelving.core/enumerate-spec](shelving/impl.clj#L197)
  - `(enumerate-spec conn spec)`
 
 Enumerates all the known records of a spec by UUID.
@@ -105,7 +105,7 @@ By default throws `me.arrdem.UnimplementedOperationException`.
 [Back to the index](/README.md#usage)
 
 
-### [shelving.core/put-rel](shelving/impl.clj#L157)
+### [shelving.core/put-rel](shelving/impl.clj#L129)
  - `(put-rel conn spec rel-id from-id to-id)`
 
 The "raw" put operation on relations.
@@ -118,7 +118,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.core/get-rel](shelving/impl.clj#L300)
+### [shelving.core/get-rel](shelving/impl.clj#L272)
  - `(get-rel conn rel-id spec id)`
 
 **UNSTABLE**: This API will probably change in the future
@@ -169,7 +169,7 @@ Queries are cached to avoid repeated compilation.
 
 [Back to the index](/README.md#usage)
 
-### [shelving.core/schema](shelving/impl.clj#L176)
+### [shelving.core/schema](shelving/impl.clj#L148)
  - `(schema conn)`
 
 Returns the schema record for a given connection.
@@ -180,7 +180,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.core/alter-schema](shelving/core.clj#L194)
+### [shelving.core/alter-schema](shelving/core.clj#L191)
  - `(alter-schema conn f & args)`
 
 Attempts alter the schema of a live connection.

--- a/docs/basic.md
+++ b/docs/basic.md
@@ -7,14 +7,14 @@ configurations. These operations should be shared by all implementations.
 
 ## Connecting
 
-### [shelving.core/open](shelving/impl.clj#L29)
+### [shelving.core/open](shelving/impl.clj#L59)
  - `(open config)`
 
 Opens a shelf for reading or writing.
 
 Shelves must implement this method.
 
-### [shelving.core/flush](shelving/impl.clj#L41)
+### [shelving.core/flush](shelving/impl.clj#L71)
  - `(flush conn)`
 
 Flushes (commits) an open shelf.
@@ -23,7 +23,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.core/close](shelving/impl.clj#L55)
+### [shelving.core/close](shelving/impl.clj#L85)
  - `(close conn)`
 
 Closes an open shelf.
@@ -38,14 +38,14 @@ By default just flushes.
 
 
 
-### [shelving.core/enumerate-specs](shelving/impl.clj#L182)
+### [shelving.core/enumerate-specs](shelving/impl.clj#L212)
  - `(enumerate-specs conn)`
 
 Enumerates all the known specs.
 
 Shelves may provide alternate implementations of this method.
 
-### [shelving.core/put-spec](shelving/core.clj#L147)
+### [shelving.core/put-spec](shelving/core.clj#L150)
  - `(put-spec conn spec val)`
  - `(put-spec conn spec id val)`
 
@@ -59,7 +59,7 @@ It is an error to specify the ID when inserting into a "value" shelf.
 
 Shelves must implement [`#'shelving.impl/put-spec`](/docs/impl.md#shelvingimplput-spec), which backs this method.
 
-### [shelving.core/get-spec](shelving/core.clj#L174)
+### [shelving.core/get-spec](shelving/core.clj#L177)
  - `(get-spec conn spec record-id)`
  - `(get-spec conn spec record-id not-found)`
 
@@ -69,7 +69,7 @@ Recovers a record from a shelf according to spec and ID, returning the given `no
 
 Shelves must implement [`#'shelving.impl/get-spec`](/docs/impl.md#shelvingimplget-spec), which backs this method.
 
-### [shelving.core/has?](shelving/impl.clj#L108)
+### [shelving.core/has?](shelving/impl.clj#L138)
  - `(has? conn spec record-id)`
 
 Indicates whether a shelf has a record of a spec.
@@ -78,7 +78,7 @@ Returns `true` if and only if the shelf contains a record if the given spec and 
 
 Implementations may provide alternate implementations of this method.
 
-### [shelving.core/count-spec](shelving/impl.clj#L209)
+### [shelving.core/count-spec](shelving/impl.clj#L239)
  - `(count-spec conn spec)`
 
 **UNSTABLE**: This API will probably change in the future
@@ -91,7 +91,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.core/enumerate-spec](shelving/impl.clj#L195)
+### [shelving.core/enumerate-spec](shelving/impl.clj#L225)
  - `(enumerate-spec conn spec)`
 
 Enumerates all the known records of a spec by UUID.
@@ -105,7 +105,7 @@ By default throws `me.arrdem.UnimplementedOperationException`.
 [Back to the index](/README.md#usage)
 
 
-### [shelving.core/put-rel](shelving/impl.clj#L127)
+### [shelving.core/put-rel](shelving/impl.clj#L157)
  - `(put-rel conn spec rel-id from-id to-id)`
 
 The "raw" put operation on relations.
@@ -118,7 +118,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.core/get-rel](shelving/impl.clj#L270)
+### [shelving.core/get-rel](shelving/impl.clj#L300)
  - `(get-rel conn rel-id spec id)`
 
 **UNSTABLE**: This API will probably change in the future
@@ -169,7 +169,7 @@ Queries are cached to avoid repeated compilation.
 
 [Back to the index](/README.md#usage)
 
-### [shelving.core/schema](shelving/impl.clj#L146)
+### [shelving.core/schema](shelving/impl.clj#L176)
  - `(schema conn)`
 
 Returns the schema record for a given connection.
@@ -180,7 +180,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.core/alter-schema](shelving/core.clj#L191)
+### [shelving.core/alter-schema](shelving/core.clj#L194)
  - `(alter-schema conn f & args)`
 
 Attempts alter the schema of a live connection.

--- a/docs/impl.md
+++ b/docs/impl.md
@@ -34,14 +34,14 @@ No fundamental connection behavior is specified or expected.
 `open` exists to differentiate between a connection's description and an active connection.
 `close` is expected to close an open connection, freeing any related resources on both the client and any implementation or server.
 
-### [shelving.impl/open](shelving/impl.clj#L59)
+### [shelving.impl/open](shelving/impl.clj#L31)
  - `(open config)`
 
 Opens a shelf for reading or writing.
 
 Shelves must implement this method.
 
-### [shelving.impl/flush](shelving/impl.clj#L71)
+### [shelving.impl/flush](shelving/impl.clj#L43)
  - `(flush conn)`
 
 Flushes (commits) an open shelf.
@@ -50,7 +50,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/close](shelving/impl.clj#L85)
+### [shelving.impl/close](shelving/impl.clj#L57)
  - `(close conn)`
 
 Closes an open shelf.
@@ -67,7 +67,7 @@ The database schema describes what kinds of values it expects to store.
 Clients MAY NOT write to relations or specs which have not been entered into the schema.
 [`#'shelving.core/put-spec`](/docs/basic.md#shelvingcoreput-spec), the intentional write API, has support for automatically manipulating and extending the store's schema.
 
-### [shelving.impl/schema](shelving/impl.clj#L176)
+### [shelving.impl/schema](shelving/impl.clj#L148)
  - `(schema conn)`
 
 Returns the schema record for a given connection.
@@ -78,7 +78,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/set-schema](shelving/impl.clj#L192)
+### [shelving.impl/set-schema](shelving/impl.clj#L164)
  - `(set-schema conn schema)`
 
 Attempts to alter the live schema of the connection by applying the given transformer function to the current schema state with any additional arguments.
@@ -101,14 +101,14 @@ The counting operation is used to attempt to optimize query implementations.
 
 Deletion of spec entries is not supported.
 
-### [shelving.impl/enumerate-specs](shelving/impl.clj#L212)
+### [shelving.impl/enumerate-specs](shelving/impl.clj#L184)
  - `(enumerate-specs conn)`
 
 Enumerates all the known specs.
 
 Shelves may provide alternate implementations of this method.
 
-### [shelving.impl/enumerate-spec](shelving/impl.clj#L225)
+### [shelving.impl/enumerate-spec](shelving/impl.clj#L197)
  - `(enumerate-spec conn spec)`
 
 Enumerates all the known records of a spec by UUID.
@@ -117,7 +117,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/count-spec](shelving/impl.clj#L239)
+### [shelving.impl/count-spec](shelving/impl.clj#L211)
  - `(count-spec conn spec)`
 
 **UNSTABLE**: This API will probably change in the future
@@ -130,7 +130,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/put-spec](shelving/impl.clj#L100)
+### [shelving.impl/put-spec](shelving/impl.clj#L72)
  - `(put-spec conn spec id val)`
 
 The "raw" put operation on values. Inserts a fully decomposed value (tuple) into the designated spec, returning the ID at which it was inserted if an ID was not provided.
@@ -143,7 +143,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/get-spec](shelving/impl.clj#L119)
+### [shelving.impl/get-spec](shelving/impl.clj#L91)
  - `(get-spec conn spec record-id)`
  - `(get-spec conn spec record-id not-found)`
 
@@ -157,7 +157,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/has?](shelving/impl.clj#L138)
+### [shelving.impl/has?](shelving/impl.clj#L110)
  - `(has? conn spec record-id)`
 
 Indicates whether a shelf has a record of a spec.
@@ -175,14 +175,14 @@ Like the values themselves, the relations can be read from, written to and count
 
 Deletion of relations is not supported.
 
-### [shelving.impl/enumerate-rels](shelving/impl.clj#L256)
+### [shelving.impl/enumerate-rels](shelving/impl.clj#L228)
  - `(enumerate-rels conn)`
 
 Enumerates all the known rels by ID (their `[from-spec to-spec]` pair). Includes aliases.
 
 Shelves may provide alternate implementation of this method.
 
-### [shelving.impl/enumerate-rel](shelving/impl.clj#L269)
+### [shelving.impl/enumerate-rel](shelving/impl.clj#L241)
  - `(enumerate-rel conn rel-id)`
 
 Enumerates the `(from-id to-id)` pairs of the given rel(ation).
@@ -191,7 +191,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/count-rel](shelving/impl.clj#L283)
+### [shelving.impl/count-rel](shelving/impl.clj#L255)
  - `(count-rel conn rel-id)`
 
 **UNSTABLE**: This API will probably change in the future
@@ -204,7 +204,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/put-rel](shelving/impl.clj#L157)
+### [shelving.impl/put-rel](shelving/impl.clj#L129)
  - `(put-rel conn spec rel-id from-id to-id)`
 
 The "raw" put operation on relations.
@@ -217,7 +217,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/get-rel](shelving/impl.clj#L300)
+### [shelving.impl/get-rel](shelving/impl.clj#L272)
  - `(get-rel conn rel-id spec id)`
 
 **UNSTABLE**: This API will probably change in the future

--- a/docs/impl.md
+++ b/docs/impl.md
@@ -34,14 +34,14 @@ No fundamental connection behavior is specified or expected.
 `open` exists to differentiate between a connection's description and an active connection.
 `close` is expected to close an open connection, freeing any related resources on both the client and any implementation or server.
 
-### [shelving.impl/open](shelving/impl.clj#L29)
+### [shelving.impl/open](shelving/impl.clj#L59)
  - `(open config)`
 
 Opens a shelf for reading or writing.
 
 Shelves must implement this method.
 
-### [shelving.impl/flush](shelving/impl.clj#L41)
+### [shelving.impl/flush](shelving/impl.clj#L71)
  - `(flush conn)`
 
 Flushes (commits) an open shelf.
@@ -50,7 +50,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/close](shelving/impl.clj#L55)
+### [shelving.impl/close](shelving/impl.clj#L85)
  - `(close conn)`
 
 Closes an open shelf.
@@ -67,7 +67,7 @@ The database schema describes what kinds of values it expects to store.
 Clients MAY NOT write to relations or specs which have not been entered into the schema.
 [`#'shelving.core/put-spec`](/docs/basic.md#shelvingcoreput-spec), the intentional write API, has support for automatically manipulating and extending the store's schema.
 
-### [shelving.impl/schema](shelving/impl.clj#L146)
+### [shelving.impl/schema](shelving/impl.clj#L176)
  - `(schema conn)`
 
 Returns the schema record for a given connection.
@@ -78,7 +78,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/set-schema](shelving/impl.clj#L162)
+### [shelving.impl/set-schema](shelving/impl.clj#L192)
  - `(set-schema conn schema)`
 
 Attempts to alter the live schema of the connection by applying the given transformer function to the current schema state with any additional arguments.
@@ -101,14 +101,14 @@ The counting operation is used to attempt to optimize query implementations.
 
 Deletion of spec entries is not supported.
 
-### [shelving.impl/enumerate-specs](shelving/impl.clj#L182)
+### [shelving.impl/enumerate-specs](shelving/impl.clj#L212)
  - `(enumerate-specs conn)`
 
 Enumerates all the known specs.
 
 Shelves may provide alternate implementations of this method.
 
-### [shelving.impl/enumerate-spec](shelving/impl.clj#L195)
+### [shelving.impl/enumerate-spec](shelving/impl.clj#L225)
  - `(enumerate-spec conn spec)`
 
 Enumerates all the known records of a spec by UUID.
@@ -117,7 +117,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/count-spec](shelving/impl.clj#L209)
+### [shelving.impl/count-spec](shelving/impl.clj#L239)
  - `(count-spec conn spec)`
 
 **UNSTABLE**: This API will probably change in the future
@@ -130,7 +130,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/put-spec](shelving/impl.clj#L70)
+### [shelving.impl/put-spec](shelving/impl.clj#L100)
  - `(put-spec conn spec id val)`
 
 The "raw" put operation on values. Inserts a fully decomposed value (tuple) into the designated spec, returning the ID at which it was inserted if an ID was not provided.
@@ -143,7 +143,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/get-spec](shelving/impl.clj#L89)
+### [shelving.impl/get-spec](shelving/impl.clj#L119)
  - `(get-spec conn spec record-id)`
  - `(get-spec conn spec record-id not-found)`
 
@@ -157,7 +157,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/has?](shelving/impl.clj#L108)
+### [shelving.impl/has?](shelving/impl.clj#L138)
  - `(has? conn spec record-id)`
 
 Indicates whether a shelf has a record of a spec.
@@ -175,14 +175,14 @@ Like the values themselves, the relations can be read from, written to and count
 
 Deletion of relations is not supported.
 
-### [shelving.impl/enumerate-rels](shelving/impl.clj#L226)
+### [shelving.impl/enumerate-rels](shelving/impl.clj#L256)
  - `(enumerate-rels conn)`
 
 Enumerates all the known rels by ID (their `[from-spec to-spec]` pair). Includes aliases.
 
 Shelves may provide alternate implementation of this method.
 
-### [shelving.impl/enumerate-rel](shelving/impl.clj#L239)
+### [shelving.impl/enumerate-rel](shelving/impl.clj#L269)
  - `(enumerate-rel conn rel-id)`
 
 Enumerates the `(from-id to-id)` pairs of the given rel(ation).
@@ -191,7 +191,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/count-rel](shelving/impl.clj#L253)
+### [shelving.impl/count-rel](shelving/impl.clj#L283)
  - `(count-rel conn rel-id)`
 
 **UNSTABLE**: This API will probably change in the future
@@ -204,7 +204,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/put-rel](shelving/impl.clj#L127)
+### [shelving.impl/put-rel](shelving/impl.clj#L157)
  - `(put-rel conn spec rel-id from-id to-id)`
 
 The "raw" put operation on relations.
@@ -217,7 +217,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-### [shelving.impl/get-rel](shelving/impl.clj#L270)
+### [shelving.impl/get-rel](shelving/impl.clj#L300)
  - `(get-rel conn rel-id spec id)`
 
 **UNSTABLE**: This API will probably change in the future

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -84,7 +84,7 @@ Same as [`#'shelving.query/q`](/docs/queries.md#shelvingqueryq) but directly acc
 
 Queries are cached to avoid repeated compilation.
 
-## [shelving.core/count-spec](shelving/impl.clj#L209)
+## [shelving.core/count-spec](shelving/impl.clj#L239)
  - `(count-spec conn spec)`
 
 **UNSTABLE**: This API will probably change in the future
@@ -97,7 +97,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-## [shelving.core/count-rel](shelving/impl.clj#L253)
+## [shelving.core/count-rel](shelving/impl.clj#L283)
  - `(count-rel conn rel-id)`
 
 **UNSTABLE**: This API will probably change in the future

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -84,7 +84,7 @@ Same as [`#'shelving.query/q`](/docs/queries.md#shelvingqueryq) but directly acc
 
 Queries are cached to avoid repeated compilation.
 
-## [shelving.core/count-spec](shelving/impl.clj#L239)
+## [shelving.core/count-spec](shelving/impl.clj#L211)
  - `(count-spec conn spec)`
 
 **UNSTABLE**: This API will probably change in the future
@@ -97,7 +97,7 @@ Shelves must implement this method.
 
 By default throws `me.arrdem.UnimplementedOperationException`.
 
-## [shelving.core/count-rel](shelving/impl.clj#L283)
+## [shelving.core/count-rel](shelving/impl.clj#L255)
  - `(count-rel conn rel-id)`
 
 **UNSTABLE**: This API will probably change in the future

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -19,7 +19,7 @@ identifiers which may be updated. Records can be inserted, updated and removed.
 In keeping with Clojure's focus on data, Shelving also supports content or <span name="values">**"value"**</span>
 storage of immutable objects. Values can only be inserted.
 
-## [shelving.core/empty-schema](shelving/schema.clj#L48)
+## [shelving.core/empty-schema](shelving/schema.clj#L49)
 
 The empty Shelving schema.
 
@@ -27,7 +27,7 @@ Should be used as the basis for all user-defined schemas.
 
 Contains no specs, no rel(ation)s, and allows the automatic creation of neither specs nor rels.
 
-## [shelving.core/value-spec](shelving/schema.clj#L108)
+## [shelving.core/value-spec](shelving/schema.clj#L109)
  - `(value-spec schema spec & {:as opts})`
 
 Enters a new spec and its subspecs into the schema, returning a new schema. The given spec and its subspecs are all entered as "value" specs which have value identity and cannot be updated. Rel(ations) between all inserted specs and their subspecs are automatically added.
@@ -36,25 +36,25 @@ Values are addressed by a content hash derived ID, are unique and cannot be dele
 
 Values may be related to other values via schema rel(ation)s. Records may relate to values, but values cannot relate to records except through reverse lookup on a record to value relation.
 
-## [shelving.core/record-spec](shelving/schema.clj#L149)
+## [shelving.core/record-spec](shelving/schema.clj#L150)
  - `(record-spec schema spec & {:as opts})`
 
 Enters a new spec and its subspecs spec into a schema, returning a new schema. The given spec is inserted as "record" spec with update-in-place capabilities, its subspecs are inserted as "value" specs.
 
 Records have traditional place semantics and are identified by randomly generated IDs, rather than the structural semantics ascribed to values.
 
-## [shelving.core/automatic-specs](shelving/schema.clj#L175)
+## [shelving.core/automatic-specs](shelving/schema.clj#L176)
  - `(automatic-specs schema)`
  - `(automatic-specs schema bool)`
 
 Function of a schema, returning a new schema which allows for the automatic addition of specs. Specs added automatically will always be "values".
 
-## [shelving.core/automatic-specs?](shelving/schema.clj#L188)
+## [shelving.core/automatic-specs?](shelving/schema.clj#L189)
  - `(automatic-specs? {:keys [automatic-specs?]})`
 
 Function of a schema, indicating whether it allows for the automatic creation of "value" specs.
 
-## [shelving.core/spec-rel](shelving/schema.clj#L267)
+## [shelving.core/spec-rel](shelving/schema.clj#L268)
  - `(spec-rel schema [from-spec to-spec :as rel-id])`
 
 Enters a rel(ation) into a schema, returning a new schema which will maintain that rel.
@@ -69,13 +69,13 @@ At insertion time, the `to-spec` must exist as a supported shelf.
 
 The `to-spec` MAY NEVER name a "record" shelf. `to-spec` must be a "value" shelf.
 
-## [shelving.core/automatic-rels](shelving/schema.clj#L335)
+## [shelving.core/automatic-rels](shelving/schema.clj#L336)
  - `(automatic-rels schema)`
  - `(automatic-rels schema bool)`
 
 Function of a schema, returning a new schema which allows for the automatic addition of relations. Relations must be between known specs, and may not relate to records.
 
-## [shelving.core/automatic-rels?](shelving/schema.clj#L348)
+## [shelving.core/automatic-rels?](shelving/schema.clj#L349)
  - `(automatic-rels? {:keys [automatic-rels?]})`
 
 Predicate indicating whether the schema supports automatic relations.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -19,7 +19,7 @@ identifiers which may be updated. Records can be inserted, updated and removed.
 In keeping with Clojure's focus on data, Shelving also supports content or <span name="values">**"value"**</span>
 storage of immutable objects. Values can only be inserted.
 
-## [shelving.core/empty-schema](shelving/schema.clj#L49)
+## [shelving.core/empty-schema](shelving/schema.clj#L32)
 
 The empty Shelving schema.
 
@@ -27,7 +27,7 @@ Should be used as the basis for all user-defined schemas.
 
 Contains no specs, no rel(ation)s, and allows the automatic creation of neither specs nor rels.
 
-## [shelving.core/value-spec](shelving/schema.clj#L109)
+## [shelving.core/value-spec](shelving/schema.clj#L92)
  - `(value-spec schema spec & {:as opts})`
 
 Enters a new spec and its subspecs into the schema, returning a new schema. The given spec and its subspecs are all entered as "value" specs which have value identity and cannot be updated. Rel(ations) between all inserted specs and their subspecs are automatically added.
@@ -36,25 +36,25 @@ Values are addressed by a content hash derived ID, are unique and cannot be dele
 
 Values may be related to other values via schema rel(ation)s. Records may relate to values, but values cannot relate to records except through reverse lookup on a record to value relation.
 
-## [shelving.core/record-spec](shelving/schema.clj#L150)
+## [shelving.core/record-spec](shelving/schema.clj#L133)
  - `(record-spec schema spec & {:as opts})`
 
 Enters a new spec and its subspecs spec into a schema, returning a new schema. The given spec is inserted as "record" spec with update-in-place capabilities, its subspecs are inserted as "value" specs.
 
 Records have traditional place semantics and are identified by randomly generated IDs, rather than the structural semantics ascribed to values.
 
-## [shelving.core/automatic-specs](shelving/schema.clj#L176)
+## [shelving.core/automatic-specs](shelving/schema.clj#L159)
  - `(automatic-specs schema)`
  - `(automatic-specs schema bool)`
 
 Function of a schema, returning a new schema which allows for the automatic addition of specs. Specs added automatically will always be "values".
 
-## [shelving.core/automatic-specs?](shelving/schema.clj#L189)
+## [shelving.core/automatic-specs?](shelving/schema.clj#L172)
  - `(automatic-specs? {:keys [automatic-specs?]})`
 
 Function of a schema, indicating whether it allows for the automatic creation of "value" specs.
 
-## [shelving.core/spec-rel](shelving/schema.clj#L268)
+## [shelving.core/spec-rel](shelving/schema.clj#L288)
  - `(spec-rel schema [from-spec to-spec :as rel-id])`
 
 Enters a rel(ation) into a schema, returning a new schema which will maintain that rel.
@@ -69,13 +69,13 @@ At insertion time, the `to-spec` must exist as a supported shelf.
 
 The `to-spec` MAY NEVER name a "record" shelf. `to-spec` must be a "value" shelf.
 
-## [shelving.core/automatic-rels](shelving/schema.clj#L336)
+## [shelving.core/automatic-rels](shelving/schema.clj#L356)
  - `(automatic-rels schema)`
  - `(automatic-rels schema bool)`
 
 Function of a schema, returning a new schema which allows for the automatic addition of relations. Relations must be between known specs, and may not relate to records.
 
-## [shelving.core/automatic-rels?](shelving/schema.clj#L349)
+## [shelving.core/automatic-rels?](shelving/schema.clj#L369)
  - `(automatic-rels? {:keys [automatic-rels?]})`
 
 Predicate indicating whether the schema supports automatic relations.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -54,7 +54,7 @@ Function of a schema, returning a new schema which allows for the automatic addi
 
 Function of a schema, indicating whether it allows for the automatic creation of "value" specs.
 
-## [shelving.core/spec-rel](shelving/schema.clj#L288)
+## [shelving.core/spec-rel](shelving/schema.clj#L304)
  - `(spec-rel schema [from-spec to-spec :as rel-id])`
 
 Enters a rel(ation) into a schema, returning a new schema which will maintain that rel.
@@ -69,13 +69,13 @@ At insertion time, the `to-spec` must exist as a supported shelf.
 
 The `to-spec` MAY NEVER name a "record" shelf. `to-spec` must be a "value" shelf.
 
-## [shelving.core/automatic-rels](shelving/schema.clj#L356)
+## [shelving.core/automatic-rels](shelving/schema.clj#L372)
  - `(automatic-rels schema)`
  - `(automatic-rels schema bool)`
 
 Function of a schema, returning a new schema which allows for the automatic addition of relations. Relations must be between known specs, and may not relate to records.
 
-## [shelving.core/automatic-rels?](shelving/schema.clj#L369)
+## [shelving.core/automatic-rels?](shelving/schema.clj#L385)
  - `(automatic-rels? {:keys [automatic-rels?]})`
 
 Predicate indicating whether the schema supports automatic relations.

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,9 @@
   :url "https://github.com/arrdem/shelving"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+
+  :exclusions [org.clojure/clojure]
+  :dependencies [[me.arrdem/clojure "1.10.0-SNAPSHOT"]
                  [org.clojure/spec.alpha "0.1.143"]
                  [io.replikativ/hasch "0.3.4"
                   :exclusions [com.cemerick/austin]]

--- a/src/dev/clj/compile_docs.clj
+++ b/src/dev/clj/compile_docs.clj
@@ -25,7 +25,7 @@
 (defn document-var [^clojure.lang.Var v heading]
   (binding [*ns* (.ns v)]
     (let [{:keys [categories arglists doc stability line file]
-         :as   var-meta} (meta v)]
+           :as   var-meta} (meta v)]
       (with-out-str
         (printf "%s [%s/%s](%s#L%s)\n"
                 heading
@@ -49,11 +49,11 @@
   (doseq [f files]
     (when (.contains (.getCanonicalPath f) "#")
       (.delete f)))
-    
+
   (let [fcache
         (->> (map (juxt identity slurp) files)
              (into {}))
-        
+
         links-map
         (reduce (fn [acc f]
                   (reduce (fn [acc [_ name]]
@@ -67,19 +67,19 @@
       (try (let [buff (get fcache f)
                  buff* (-> buff
                            (str/replace var-doc-pattern
-                                    (fn [[original heading name _ path line _body]]
-                                      (try (let [sym (symbol name)]
-                                             (require (symbol (namespace sym)))
-                                             (or (some-> sym resolve (document-var heading))
-                                                 original))
-                                           (catch Exception e
-                                             original))))
+                                        (fn [[original heading name _ path line _body]]
+                                          (try (let [sym (symbol name)]
+                                                 (require (symbol (namespace sym)))
+                                                 (or (some-> sym resolve (document-var heading))
+                                                     original))
+                                               (catch Exception e
+                                                 original))))
                            (str/replace var-quote-pattern
-                                    (fn [[original name suffix?]]
-                                      (if-let [link (get links-map name)]
-                                        (format "[`#'%s`](%s)" name link)
-                                        (do (log/warnf "%s: Couldn't find a link for %s!" f name)
-                                            original))))
+                                        (fn [[original name suffix?]]
+                                          (if-let [link (get links-map name)]
+                                            (format "[`#'%s`](%s)" name link)
+                                            (do (log/warnf "%s: Couldn't find a link for %s!" f name)
+                                                original))))
                            (str/replace #"\n{2,}\Z" "\n"))]
              (when  (not= buff buff*)
                (log/infof "Rebuilt %s" f)

--- a/src/main/clj/data_readers.clj
+++ b/src/main/clj/data_readers.clj
@@ -1,0 +1,1 @@
+{shelving/id shelving.schema/read-id}

--- a/src/main/clj/data_readers.edn
+++ b/src/main/clj/data_readers.edn
@@ -1,0 +1,1 @@
+{shelving/id shelving.impl/read-id}

--- a/src/main/clj/data_readers.edn
+++ b/src/main/clj/data_readers.edn
@@ -1,1 +1,0 @@
-{shelving/id shelving.impl/read-id}

--- a/src/main/clj/shelving/impl.clj
+++ b/src/main/clj/shelving/impl.clj
@@ -6,7 +6,9 @@
    :license "Eclipse Public License 1.0",
    :added   "0.0.0"}
   (:refer-clojure :exclude [flush get])
-  (:require [shelving.schema :as schema])
+  (:require [shelving.schema :as schema]
+            [shelving.spec.walk :as s.w]
+            [clojure.tools.logging :as log])
   (:import me.arrdem.UnimplementedOperationException))
 
 (defn- dx
@@ -282,8 +284,7 @@
   relation.
 
   Shelves may provide more efficient implementations of this method."
-  {:categories #{:shelving.core/impl :shelving.core/rel}
-   :stability  :stability/unstable
+  {:stability  :stability/unstable
    :added      "0.0.0"
    :arglists   '([conn rel-id spec id])}
   #'dx)
@@ -294,3 +295,30 @@
                       #(when (= id (first %)) (second %))
                       #(when (= id (second %)) (first %)))]
     (keep f (enumerate-rel conn real-rel-id))))
+
+(defn decompose
+  "Given a schema, a spec in the schema, a record ID and the record as a
+  value, decompose the record into its direct descendants and relations
+  thereto."
+  {:stability  :stability/stable
+   :added      "0.0.0"}
+  [schema spec id val]
+  (let [acc! (volatile! [])
+        ids (volatile! [])]
+    (log/info id val)
+    (binding [s.w/*walk-through-aliases* nil
+              s.w/*walk-through-multis*  nil]
+      (s.w/walk-with-spec
+       (fn [subspec subval]
+         (vswap! ids conj (schema/id-for-record schema subspec subval))
+         subval)
+       (fn [subspec subval]
+         (let [id* (last @ids)]
+           (vswap! ids pop)
+           (when (and (qualified-keyword? subspec)
+                      (not= spec subspec))
+             (vswap! acc! conj [:record subspec id* subval])
+             (vswap! acc! conj [:rel [spec subspec] id id*]))
+           id*))
+       spec val)
+      @acc!)))

--- a/src/main/clj/shelving/log_shelf.clj
+++ b/src/main/clj/shelving/log_shelf.clj
@@ -30,10 +30,7 @@
     ;; Doesn't even bother with schema validation
     ;;
     ;; SERIOUSLY DON'T USE THIS
-    {:type              ::shelf
-     ::state            state
-     :path              path
-     :flush-after-write (:flush-after-write s)}))
+    (merge s {:type ::shelf, ::state state})))
 
 ;; EDN shelves don't have write batching and are always open.
 (defmethod imp/open ::shelf [s] s)

--- a/src/main/clj/shelving/log_shelf.clj
+++ b/src/main/clj/shelving/log_shelf.clj
@@ -97,7 +97,6 @@
 (defmethod imp/count-spec ::shelf [conn spec]
   (count (imp/enumerate-spec conn spec)))
 
-
 (defn- enumerate-rel* [[t & t* :as tuples] from-spec fr? to-spec tr? invalidated]
   (if-not tuples nil
           (let [tv? (if tr? (complement invalidated) (constantly true))
@@ -118,7 +117,7 @@
               (if fr?
                 (recur t* from-spec fr? to-spec tr? (conj invalidated some-id))
                 (recur t* from-spec fr? to-spec tr? invalidated))
-              
+
               :else
               (recur t* from-spec fr? to-spec tr? invalidated)))))
 
@@ -139,7 +138,7 @@
           (let [valid? (complement invalidated)]
             (match t
               (:or [(id :guard valid?)    [from-spec to-spec] (to-id :guard valid?)]
-                   [(to-id :guard valid?) [to-spec from-spec] (id :guard valid?)]) 
+                   [(to-id :guard valid?) [to-spec from-spec] (id :guard valid?)])
               (cons to-id (lazy-seq (get-rel* rel id ts* from-record? to-record? invalidated)))
 
               [from-spec id _]

--- a/src/main/clj/shelving/map_shelf.clj
+++ b/src/main/clj/shelving/map_shelf.clj
@@ -97,7 +97,7 @@
   "Implementation detail.
   Backs `#'sh/put`, providing the actual recursive write logic."
   [state schema spec record-id record]
-  (assert (uuid? record-id))
+  (assert (sh/id? record-id))
   (assert (sh/has-spec? schema spec))
   (assert (s/valid? spec record))
   (cond-> state

--- a/src/main/clj/shelving/map_shelf.clj
+++ b/src/main/clj/shelving/map_shelf.clj
@@ -97,9 +97,6 @@
   "Implementation detail.
   Backs `#'sh/put`, providing the actual recursive write logic."
   [state schema spec record-id record]
-  (assert (sh/id? record-id))
-  (assert (sh/has-spec? schema spec))
-  (assert (s/valid? spec record))
   (cond-> state
     ;; FIXME (arrdem 2018-02-25):
     ;;   can skip invalidation when we're inserting a new record
@@ -108,7 +105,7 @@
 
 (defmethod impl/put-spec ::shelf
   [{:keys [::state flush-after-write] :as conn} spec id val]
-  (swap! state put* (sh/schema conn) spec id val) 
+  (swap! state put* (sh/schema conn) spec id val)
   (when flush-after-write
     (sh/flush conn))
   id)

--- a/src/main/clj/shelving/map_shelf.clj
+++ b/src/main/clj/shelving/map_shelf.clj
@@ -36,7 +36,7 @@
           ;; Install the schema in a new db
           (merge persisted-schema schema))]
 
-    {:type ::shelf, ::state (atom (assoc persisted-state :schema live-schema))}))
+    (merge s {:type ::shelf, ::state (atom (assoc persisted-state :schema live-schema))})))
 
 ;; EDN shelves don't have write batching and are always open.
 (defmethod impl/open ::shelf [s] s)

--- a/src/main/clj/shelving/query/analyzer.clj
+++ b/src/main/clj/shelving/query/analyzer.clj
@@ -111,7 +111,7 @@
                          ;; FIXME (arrdem 2018-02-17):
                          ;;   Only tuple clauses are supported at this time, if not and guard
                          ;;   clauses get added, they'll need to be supported here.
-                         ))
+))
                      where)]
     (assoc query
            :where where*

--- a/src/main/clj/shelving/query/compiler.clj
+++ b/src/main/clj/shelving/query/compiler.clj
@@ -4,8 +4,8 @@
    :license "Eclipse Public License 1.0",
    :added   "0.0.0"}
   (:require [clojure.core.match :refer [match]]
-            [shelving.query.planner :as p]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [shelving.query.planner :as p]))
 
 (defn compile-op
   "Implementation detail of `#'compile-clause`.
@@ -24,28 +24,28 @@
   (match clause
     {:type ::p/scan-rel, :rel rel, :id id}
     `(mapcat (fn [~'state]
-               #_(println ~(str "DEBUG " (name lvar) " " (pr-str clause) "]\n        ") ~'state)
+               (log/debug ~(str (name lvar) " " (pr-str clause) "]\n        ") ~'state)
                (map (fn [~'e]
                       (assoc ~'state '~lvar ~'e))
                     (shelving.core/get-rel ~'conn ~rel ~id))))
 
     {:type ::p/scan-spec :spec spec}
     `(mapcat (fn [~'state]
-               #_(println ~(str "DEBUG " (name lvar) " " (pr-str clause) "]\n        ") ~'state)
+               (log/debug ~(str (name lvar) " " (pr-str clause) "]\n        ") ~'state)
                (map (fn [~'e]
                       (assoc ~'state '~lvar ~'e))
                     (shelving.core/enumerate-spec ~'conn ~spec))))
 
     {:type ::p/project :rel rel :left left-var}
     `(mapcat (fn [~'state]
-               #_(println ~(str "DEBUG " (name lvar) " " (pr-str clause) "]\n        ") ~'state)
+               (log/debug ~(str (name lvar) " " (pr-str clause) "]\n        ") ~'state)
                (map (fn [~'e]
                       (assoc ~'state '~lvar ~'e))
                     (shelving.core/get-rel ~'conn ~rel (get ~'state '~left-var)))))
 
     {:type ::p/intersect :left left-var :right right-var}
     `(keep (fn [~'state]
-             #_(println ~(str "DEBUG " (name lvar) " " (pr-str clause) "]\n        ") ~'state)
+             (log/debug ~(str (name lvar) " " (pr-str clause) "]\n        ") ~'state)
              (let [l# (get ~'state '~left-var)]
                (when (= l# (get ~'state '~right-var))
                  (assoc ~'state '~lvar l#)))))))

--- a/src/main/clj/shelving/spec.clj
+++ b/src/main/clj/shelving/spec.clj
@@ -7,9 +7,6 @@
             [clojure.core.match :refer [match]]
             [detritus.update :refer [fix]]))
 
-;; Not a require to avoid a cyclic dependency
-(alias 'sh 'shelving.core)
-
 (defn keys-as-map
   "Implementation detail of `#'walk-with-spec`.
 
@@ -18,8 +15,7 @@
 
   Imposes the restriction that there be PRECISELY ONE spec for any
   given key. Will throw otherwise."
-  {:categories #{::sh/spec}
-   :stability  :stability/unstable
+  {:stability  :stability/unstable
    :added      "0.0.0"}
   [keys-form]
   (let [[_keys & {:keys [req req-un opt opt-un] :as opts}] keys-form]
@@ -30,8 +26,7 @@
 (defn pred->preds
   "Given a `s/describe*` or 'pred' structure, return its component
   preds (keyword identifiers and predicate forms)."
-  {:categories #{::sh/spec}
-   :stability  :stability/unstable
+  {:stability  :stability/unstable
    :added      "0.0.0"}
   [s]
   (match s
@@ -51,8 +46,7 @@
   "Given a keyword naming a spec, return the depth-first .
 
   Does not recur across spec keywords."
-  {:categories #{::sh/spec}
-   :stability  :stability/unstable
+  {:stability  :stability/unstable
    :added      "0.0.0"}
   [s]
   (let [s* (or (s/get-spec s) ::s/unknown)]
@@ -69,8 +63,7 @@
   Throws if a `::s/unknown` spec is encountered.
 
   Named for `#'file-seq`."
-  {:categories #{::sh/spec}
-   :stability  :stability/unstable
+  {:stability  :stability/unstable
    :added      "0.0.0"}
   [s & specs]
   (loop [[s & specs* :as specs] (cons s specs)

--- a/src/main/clj/shelving/spec/walk.clj
+++ b/src/main/clj/shelving/spec/walk.clj
@@ -60,7 +60,7 @@ Default is `nil`, meaning infinitely many."}
      ~else))
 
 (defmethod walk-with-spec* ::alias [spec alias obj before after]
-  {:pre [(qualified-keyword? alias)]} 
+  {:pre [(qualified-keyword? alias)]}
   (as-> obj %
     (before spec %)
     (do (s/assert spec %) %)
@@ -78,7 +78,7 @@ Default is `nil`, meaning infinitely many."}
 (defmethod walk-with-spec* `s/multi-spec [spec [_ mm k] obj before after]
   (as-> obj %
     (before spec %)
-    (do (s/assert spec %) %) 
+    (do (s/assert spec %) %)
     (let [spec* ((find-var mm) %)]
       (with-counter *walk-through-multis*
         (walk-with-spec before after spec* %) %))

--- a/src/main/jvm/me/arrdem/shelving/RecordIdentifier.java
+++ b/src/main/jvm/me/arrdem/shelving/RecordIdentifier.java
@@ -1,0 +1,40 @@
+package me.arrdem.shelving;
+
+import clojure.lang.*;
+
+import java.util.Objects;
+import java.util.UUID;
+import static clojure.lang.RT.cons;
+
+public class RecordIdentifier implements clojure.lang.Seqable {
+    public final UUID id;
+    public final Keyword spec;
+
+    public RecordIdentifier(Keyword spec, UUID id) {
+        this.spec = spec;
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RecordIdentifier that = (RecordIdentifier) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(spec, that.spec);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    public String toString() {
+        return String.format("#shelving/id [%s %s]", this.spec, this.id);
+    }
+
+    @Override
+    public ISeq seq() {
+        return cons(this.spec, cons(this.id, null));
+    }
+}

--- a/src/main/jvm/me/arrdem/shelving/RecordIdentifier.java
+++ b/src/main/jvm/me/arrdem/shelving/RecordIdentifier.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import java.util.UUID;
 import static clojure.lang.RT.cons;
 
-public class RecordIdentifier implements clojure.lang.Seqable {
+public class RecordIdentifier implements ITaggedLiteral {
     public final UUID id;
     public final Keyword spec;
 
@@ -33,8 +33,11 @@ public class RecordIdentifier implements clojure.lang.Seqable {
         return String.format("#shelving/id [%s %s]", this.spec, this.id);
     }
 
-    @Override
-    public ISeq seq() {
-        return cons(this.spec, cons(this.id, null));
+    public Symbol getTag() {
+        return Symbol.intern("shelving", "id");
+    }
+
+    public Object getForm() {
+        return PersistentVector.create(this.spec, this.id);
     }
 }

--- a/src/test/clj/shelving/parser_test.clj
+++ b/src/test/clj/shelving/parser_test.clj
@@ -48,8 +48,7 @@
 
              :shelving.query.parser.map/find
              :shelving.query.parser.map/in
-             :shelving.query.parser.map/where
-             ]]
+             :shelving.query.parser.map/where]]
     (t/testing (format "Attempting to generate examples of spec %s" s)
       (t/is (sgen/sample (s/gen s))))))
 

--- a/src/test/clj/shelving/query_test.clj
+++ b/src/test/clj/shelving/query_test.clj
@@ -42,22 +42,22 @@
                   (map '?qux)
                   set))))
 
-    (t/testing "Testing using ::bar as a pivot table between ::foo and ::qux"
-      (let [single-q-fn (q *conn '[:find  [?foo]
-                                   :in    [?b]
-                                   :where [[?bar [::bar ::qux] ?b]
-                                           [?bar [::bar ::foo] ?foo]]])
-            multi-q-fn  (q *conn '[:find  [?foo]
-                                   :in    [?b ...]
-                                   :where [[?bar [::bar ::qux] ?b]
-                                           [?bar [::bar ::foo] ?foo]]])]
-        (doseq [[b s]
-                [[3 #{"a"}]
-                 [2 #{"a"}]
-                 [1 #{"a" "b" "c"}]]]
-          (t/is (= s
-                   (->> (single-q-fn *conn b) (map '?foo) set)
-                   (->> (multi-q-fn *conn [b]) (map '?foo) set)))))
+  (t/testing "Testing using ::bar as a pivot table between ::foo and ::qux"
+    (let [single-q-fn (q *conn '[:find  [?foo]
+                                 :in    [?b]
+                                 :where [[?bar [::bar ::qux] ?b]
+                                         [?bar [::bar ::foo] ?foo]]])
+          multi-q-fn  (q *conn '[:find  [?foo]
+                                 :in    [?b ...]
+                                 :where [[?bar [::bar ::qux] ?b]
+                                         [?bar [::bar ::foo] ?foo]]])]
+      (doseq [[b s]
+              [[3 #{"a"}]
+               [2 #{"a"}]
+               [1 #{"a" "b" "c"}]]]
+        (t/is (= s
+                 (->> (single-q-fn *conn b) (map '?foo) set)
+                 (->> (multi-q-fn *conn [b]) (map '?foo) set)))))
 
     (t/is (= #{1}
              (->> (q! *conn

--- a/src/test/clj/shelving/query_test.clj
+++ b/src/test/clj/shelving/query_test.clj
@@ -18,28 +18,29 @@
       (sh/spec-rel [::bar ::foo])
       (sh/spec-rel [::bar ::qux])))
 
-(t/deftest examples-test 
+(def *conn
   (let [*conn (-> (->LogShelf schema "target/query-test.edn"
                               :flush-after-write false
                               :load false)
                   (sh/open))]
-
     (sh/put-spec *conn ::bar {:foo "a" :qux 1})
     (sh/put-spec *conn ::bar {:foo "a" :qux 2})
     (sh/put-spec *conn ::bar {:foo "a" :qux 3})
     (sh/put-spec *conn ::bar {:foo "b" :qux 1})
     (sh/put-spec *conn ::bar {:foo "c" :qux 1})
+    *conn))
 
-    (t/testing "Testing unconstrained selects"
-      (t/is (= #{"a" "b" "c"}
-               (->> (q! *conn '[:find [[:from ::foo ?foo]]])
-                    (map '?foo)
-                    set)))
+(t/deftest examples-test
+  (t/testing "Testing unconstrained selects"
+    (t/is (= #{"a" "b" "c"}
+             (->> (q! *conn '[:find [[:from ::foo ?foo]]])
+                  (map '?foo)
+                  set)))
 
-      (t/is (= #{1 2 3}
-               (->> (q! *conn '[:find [[:from ::qux ?qux]]])
-                    (map '?qux)
-                    set))))
+    (t/is (= #{1 2 3}
+             (->> (q! *conn '[:find [[:from ::qux ?qux]]])
+                  (map '?qux)
+                  set))))
 
     (t/testing "Testing using ::bar as a pivot table between ::foo and ::qux"
       (let [single-q-fn (q *conn '[:find  [?foo]
@@ -58,20 +59,20 @@
                    (->> (single-q-fn *conn b) (map '?foo) set)
                    (->> (multi-q-fn *conn [b]) (map '?foo) set)))))
 
-      (t/is (= #{1}
-               (->> (q! *conn
-                        '[:find  [?qux]
-                          :where [[?bar [::bar ::qux] ?qux]
-                                  [?bar [::bar ::foo] "b"]]])
-                    (map '?qux)
-                    set)))
+    (t/is (= #{1}
+             (->> (q! *conn
+                      '[:find  [?qux]
+                        :where [[?bar [::bar ::qux] ?qux]
+                                [?bar [::bar ::foo] "b"]]])
+                  (map '?qux)
+                  set)))
 
-      (t/is (= 3
-               (->> (q! *conn
-                        '[:find  [?bar]
-                          :where [[?bar [::bar ::qux] 1]]])
-                    count)
+    (t/is (= 3
+             (->> (q! *conn
+                      '[:find  [?bar]
+                        :where [[?bar [::bar ::qux] 1]]])
+                  count)
 
-               (->> (q! *conn
-                        '[:find ?bar :where [?bar [::bar ::qux] 1]])
-                    count))))))
+             (->> (q! *conn
+                      '[:find ?bar :where [?bar [::bar ::qux] 1]])
+                  count)))))


### PR DESCRIPTION
This finishes off the work from #9. With this changeset, spec described substructures of entered records are only serialized as "pointers" to the structure they already relate to.

This changeset has some other stuff going on which isn't great. In order to make the pointers context free, they're qualified with the spec in which they reside. This makes it convenient for them to work as EDN reader literals (also print-dup for the compiler), which begat https://github.com/arrdem/clojure/commit/bd14f3d06c116e6d9a360e5c6d090b2fff1dda86 because .... it looks like that interface was never well considered? Definitely wasn't designed for user defined types to interface with which is a shame.

For the most part swapping out the ID machinery was harmless, although it does beg some questions about the current relation notation. It's fine at the query level I think, but a bunch of the APIs are predicated on the expectation that a spec has to be passed along with the ID because it couldn't be recovered from the ID. That's now wrong which means those signatures could be cleaned up.

Some of the docs will need overhauling as well.