### PR TITLE
Add utility for reading shelf files

### DIFF
--- a/src/main/clj/shelving/log_shelf.clj
+++ b/src/main/clj/shelving/log_shelf.clj
@@ -8,10 +8,10 @@
    :license "Eclipse Public License 1.0",
    :added   "0.1.0"}
   (:require [clojure.core.match :refer [match]]
-            [clojure.edn :as edn]
             [clojure.java.io :as io]
             [shelving.core :as sh]
-            [shelving.impl :as imp]))
+            [shelving.impl :as imp]
+            [shelving.schema :as schema]))
 
 ;; Configs open into shelves
 (defmethod imp/open ::config [{:keys [path schema load] :as s}]
@@ -23,7 +23,7 @@
                      (-> path
                          io/reader
                          java.io.PushbackReader.
-                         edn/read)
+                         schema/read-with-shelving-tags)
                      (list))
                    (cons [:schema schema])
                    atom)]

--- a/src/main/clj/shelving/map_shelf.clj
+++ b/src/main/clj/shelving/map_shelf.clj
@@ -5,10 +5,10 @@
    :added   "0.1.0"}
   (:require [shelving.core :as sh]
             [shelving.impl :as impl]
-            [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
-            [clojure.set :refer [superset?]]))
+            [clojure.set :refer [superset?]]
+            [shelving.schema :as schema]))
 
 ;; Configs open into shelves
 (defmethod impl/open ::config [{:keys [path schema load] :as s}]
@@ -21,7 +21,7 @@
           (-> path
               io/reader
               java.io.PushbackReader.
-              edn/read
+              schema/read-with-shelving-tags
               ((fn [v] (assert (map? v)) v)))
           {})
 

--- a/src/main/clj/shelving/schema.clj
+++ b/src/main/clj/shelving/schema.clj
@@ -10,7 +10,8 @@
   {:authors ["Reid \"arrdem\" McKenzie <me@arrdem.com>"],
    :license "Eclipse Public License 1.0",
    :added   "0.0.0"}
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.edn :as edn]
+            [clojure.spec.alpha :as s]
             [clojure.tools.logging :as log]
             [hasch.core :refer [uuid]]
             [hasch.benc :refer [magics PHashCoercion -coerce
@@ -70,6 +71,15 @@
                        :spec    spec
                        :record? record?}
                       e)))))
+
+(defn read-with-shelving-tags
+  "provide shelving reader tags for the edn reader, useful for reading serialized
+  shelves"
+  {:categories #{::schema}
+   :added "0.0.0"}
+  [stream]
+  (edn/read {:readers {'shelving/id read-id}}
+            stream))
 
 (defn has-spec?
   "Helper used for preconditions."
@@ -250,7 +260,7 @@
   "Helper for use in checking compatibility between database persistable specs.
   Because proving equivalence on specs is basically impossible, we'll
   start with equality.
-  
+
   Returns a sequence of problems encountered while checking
   compatibility."
   {:categories #{::schema}


### PR DESCRIPTION
Initial creation of a shelf always works, when files are blank.

When we attempt to read a shelf that's been flushed, the reader for the #shelving/id tag isn't available.

This utility function provides it.